### PR TITLE
feat: add action introspection, validation error types, and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ash_typescript contributors <https://github.com/ash-project/ash_typescript/graphs.contributors>
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
 #
 # SPDX-License-Identifier: MIT
 
@@ -21,11 +21,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-ash_typescript-*.tar
+ash_introspection-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
-
-test/ts/node_modules/
-test/ts/generated.ts
-test/ts/**/*.js

--- a/README.md
+++ b/README.md
@@ -1,0 +1,711 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_introspection contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# AshIntrospection
+
+![Elixir CI](https://github.com/ash-project/ash_introspection/workflows/CI/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Hex version badge](https://img.shields.io/hexpm/v/ash_introspection.svg)](https://hex.pm/packages/ash_introspection)
+[![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/ash_introspection)
+
+**Shared core library for Ash interoperability with multiple languages**
+
+AshIntrospection provides the foundational modules used by language-specific generators like [AshTypescript](https://github.com/ash-project/ash_typescript) and AshKotlinMultiplatform. It enables seamless RPC communication between Elixir/Ash backends and clients in TypeScript, Kotlin, Swift, and other languages.
+
+## Features
+
+- **Unified Type Introspection** - Consistent type classification and analysis across all Ash types
+- **Language-Agnostic RPC Pipeline** - Execute Ash actions with field selection, filtering, and pagination
+- **Bidirectional Field Name Mapping** - Convert between snake_case (Elixir) and camelCase (clients)
+- **Type-Driven Value Formatting** - Format values based on their Ash types for input/output
+- **Comprehensive Error Handling** - Standardized error responses with field paths and interpolation
+- **Code Generation Utilities** - Type discovery, action introspection, and validation error classification
+
+## Installation
+
+Add to your `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:ash_introspection, "~> 0.2"}
+  ]
+end
+```
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│           Language-Specific Generators                      │
+│        (AshTypescript, AshKotlinMultiplatform)             │
+└────────────────────┬────────────────────────────────────────┘
+                     │ delegates to
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│         AshIntrospection (Shared Core Library)             │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  Type System                                        │   │
+│  │  • Introspection - Type classification & unwrap     │   │
+│  │  • ResourceFields - Field type lookup               │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  RPC Pipeline (4-Stage)                             │   │
+│  │  • Stage 1: Parse request (language-specific)       │   │
+│  │  • Stage 2: Execute Ash action                      │   │
+│  │  • Stage 3: Process result (extract fields)         │   │
+│  │  • Stage 4: Format output (convert field names)     │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  Code Generation                                    │   │
+│  │  • TypeDiscovery - Resource & type scanning         │   │
+│  │  • ActionIntrospection - Action analysis            │   │
+│  │  • ValidationErrorTypes - Error type classification │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    Ash Framework                            │
+│          (Resources, Types, Queries, Changesets)           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Module Reference
+
+### Type System
+
+| Module | Description |
+|--------|-------------|
+| `AshIntrospection.TypeSystem.Introspection` | Core type classification, NewType unwrapping, union extraction |
+| `AshIntrospection.TypeSystem.ResourceFields` | Unified field lookup for attributes, calculations, relationships |
+
+### RPC Runtime
+
+| Module | Description |
+|--------|-------------|
+| `AshIntrospection.Rpc.Request` | Request data structure for the RPC pipeline |
+| `AshIntrospection.Rpc.Pipeline` | Language-agnostic 4-stage action execution pipeline |
+| `AshIntrospection.Rpc.ValueFormatter` | Bidirectional type-driven value formatting |
+| `AshIntrospection.Rpc.ResultProcessor` | Field extraction from action results |
+| `AshIntrospection.Rpc.FieldExtractor` | Unified extraction for maps, structs, keywords, tuples |
+
+### Field Processing
+
+| Module | Description |
+|--------|-------------|
+| `AshIntrospection.Rpc.FieldProcessing.Atomizer` | Convert client field names to atoms |
+| `AshIntrospection.Rpc.FieldProcessing.FieldSelector` | Type-driven recursive field selection |
+| `AshIntrospection.Rpc.FieldProcessing.Validation` | Duplicate detection and field validation |
+
+### Error Handling
+
+| Module | Description |
+|--------|-------------|
+| `AshIntrospection.Rpc.Error` | Protocol for extracting exception information |
+| `AshIntrospection.Rpc.ErrorBuilder` | Comprehensive error message generation |
+| `AshIntrospection.Rpc.Errors` | Central error processing pipeline |
+| `AshIntrospection.Rpc.DefaultErrorHandler` | Pass-through error handler |
+
+### Code Generation
+
+| Module | Description |
+|--------|-------------|
+| `AshIntrospection.Codegen.TypeDiscovery` | Recursive resource and type scanning |
+| `AshIntrospection.Codegen.ActionIntrospection` | Action pagination, input, and return type analysis |
+| `AshIntrospection.Codegen.ValidationErrorTypes` | Validation error type classification |
+
+### Formatting Utilities
+
+| Module | Description |
+|--------|-------------|
+| `AshIntrospection.FieldFormatter` | Field name formatting (camelCase, PascalCase, snake_case) |
+| `AshIntrospection.Helpers` | Low-level case conversion utilities |
+
+## RPC Pipeline
+
+The RPC pipeline executes Ash actions in four stages:
+
+### Stage 1: Parse Request (Language-Specific)
+
+Implemented by each language generator. Parses and validates client input, builds the `Request` struct.
+
+### Stage 2: Execute Ash Action
+
+```elixir
+{:ok, result} = AshIntrospection.Rpc.Pipeline.execute_ash_action(request, config)
+```
+
+Executes read, create, update, destroy, or generic actions with proper authorization.
+
+### Stage 3: Process Result
+
+```elixir
+{:ok, filtered} = AshIntrospection.Rpc.Pipeline.process_result(result, request, config)
+```
+
+Applies field selection using the pre-computed extraction template.
+
+### Stage 4: Format Output
+
+```elixir
+formatted = AshIntrospection.Rpc.Pipeline.format_output_with_request(filtered, request, config)
+```
+
+Converts field names and structures for client consumption.
+
+### Pipeline Configuration
+
+```elixir
+config = %{
+  input_field_formatter: :camel_case,      # Parse camelCase from client
+  output_field_formatter: :camel_case,     # Output camelCase to client
+  field_names_callback: :interop_field_names,
+  not_found_error?: true,                  # Return error for missing records
+  get_original_field_name: fn resource, client_key ->
+    # Custom field name resolution
+  end,
+  format_field_for_client: fn field_name, resource, formatter ->
+    # Custom field name formatting
+  end
+}
+```
+
+## Field Name Mapping
+
+### The `interop_field_names/0` Callback
+
+Types can define field name mappings for client compatibility:
+
+```elixir
+defmodule MyApp.TaskStats do
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        is_active?: [type: :boolean],
+        task_count: [type: :integer]
+      ]
+    ]
+
+  # Map invalid identifiers to valid client names
+  def interop_field_names do
+    [
+      is_active?: "isActive",
+      task_count: "taskCount"
+    ]
+  end
+end
+```
+
+### The `interop_type_name/0` Callback
+
+Custom types can specify their representation in generated code:
+
+```elixir
+defmodule MyApp.Money do
+  use Ash.Type
+
+  def interop_type_name, do: "Money"
+
+  # ... type implementation
+end
+```
+
+## Type-Driven Dispatch
+
+Many modules use a unified dispatch pattern based on `{type, constraints}` tuples:
+
+```elixir
+# ValueFormatter dispatches based on type
+ValueFormatter.format(value, Ash.Type.Map, [fields: [...]], :output, config)
+
+# ResultProcessor extracts fields based on type
+ResultProcessor.process(result, template, resource, config)
+
+# FieldSelector validates based on type
+FieldSelector.process(fields, resource, action, config)
+```
+
+This makes types self-describing and enables consistent handling across all modules.
+
+## Code Generation Utilities
+
+### Type Discovery
+
+Scan resources to find all referenced types:
+
+```elixir
+alias AshIntrospection.Codegen.TypeDiscovery
+
+# Find all resources referenced by RPC resources
+{:ok, resources} = TypeDiscovery.scan_rpc_resources(rpc_resources, domain)
+
+# Find embedded resources
+embedded = TypeDiscovery.find_embedded_resources(resources, domain)
+
+# Find types with field constraints
+typed_structs = TypeDiscovery.find_field_constrained_types(resources, domain)
+```
+
+### Action Introspection
+
+Analyze action characteristics:
+
+```elixir
+alias AshIntrospection.Codegen.ActionIntrospection
+
+# Pagination support
+ActionIntrospection.action_supports_pagination?(action)
+ActionIntrospection.action_supports_offset_pagination?(action)
+ActionIntrospection.action_supports_keyset_pagination?(action)
+
+# Input requirements
+ActionIntrospection.action_input_type(resource, action)  # :required | :optional | :none
+ActionIntrospection.get_required_inputs(resource, action)
+ActionIntrospection.get_optional_inputs(resource, action)
+
+# Return type analysis for generic actions
+ActionIntrospection.action_returns_field_selectable_type?(action)
+# => {:ok, :resource, MyApp.User}
+# => {:ok, :array_of_resource, MyApp.User}
+# => {:ok, :typed_map, [field: [type: :string]]}
+# => {:error, :not_field_selectable_type}
+```
+
+### Validation Error Types
+
+Classify validation error types for code generation:
+
+```elixir
+alias AshIntrospection.Codegen.ValidationErrorTypes
+
+# Classify a type's error structure
+{:ok, classification} = ValidationErrorTypes.classify_error_type(type, constraints)
+# => {:primitive_errors, nil}
+# => {:resource_errors, MyApp.Address}
+# => {:typed_container_errors, [{:name, {:primitive_errors, nil}}, ...]}
+# => {:array_errors, {:resource_errors, MyApp.Item}}
+
+# Classify action input errors
+classifications = ValidationErrorTypes.classify_action_input_errors(resource, action)
+# => [{:title, {:primitive_errors, nil}, %Ash.Resource.Attribute{...}}, ...]
+```
+
+---
+
+# Integrating a New Language
+
+This section guides you through creating a new language generator (e.g., AshKotlin, AshSwift, AshGo) using AshIntrospection.
+
+## Overview
+
+A language generator typically provides:
+
+1. **Code Generation** - Generate types, interfaces, and RPC client functions
+2. **RPC Runtime** - Execute Ash actions from client requests
+3. **DSL Extensions** - Configure which actions to expose
+
+## Step 1: Project Setup
+
+Create a new Elixir package:
+
+```elixir
+# mix.exs
+defmodule AshKotlin.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :ash_kotlin,
+      version: "0.1.0",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:ash, "~> 3.0"},
+      {:ash_introspection, "~> 0.2"},
+      {:spark, "~> 2.0"}
+    ]
+  end
+end
+```
+
+## Step 2: Type Mapping
+
+Create a module to map Ash types to your target language:
+
+```elixir
+defmodule AshKotlin.Codegen.TypeMapper do
+  alias AshIntrospection.TypeSystem.Introspection
+
+  @primitive_types %{
+    Ash.Type.String => "String",
+    Ash.Type.Integer => "Int",
+    Ash.Type.Float => "Double",
+    Ash.Type.Boolean => "Boolean",
+    Ash.Type.UUID => "String",
+    Ash.Type.Date => "LocalDate",
+    Ash.Type.DateTime => "Instant"
+  }
+
+  def map_type(type, constraints \\ []) do
+    # Unwrap NewTypes first
+    {unwrapped, full_constraints} = Introspection.unwrap_new_type(type, constraints)
+
+    cond do
+      # Arrays
+      match?({:array, _}, type) ->
+        {:array, inner} = type
+        inner_type = map_type(inner, Keyword.get(constraints, :items, []))
+        "List<#{inner_type}>"
+
+      # Primitives
+      Map.has_key?(@primitive_types, unwrapped) ->
+        Map.get(@primitive_types, unwrapped)
+
+      # Embedded resources
+      Introspection.is_embedded_resource?(unwrapped) ->
+        build_type_name(unwrapped)
+
+      # Custom types with interop_type_name
+      Introspection.is_custom_interop_type?(unwrapped) ->
+        unwrapped.interop_type_name()
+
+      # Typed structs
+      Introspection.has_field_constraints?(full_constraints) ->
+        instance_of = Keyword.get(full_constraints, :instance_of)
+        if instance_of, do: build_type_name(instance_of), else: "Map<String, Any>"
+
+      # Unions
+      unwrapped == Ash.Type.Union ->
+        "Any"  # Or generate sealed class
+
+      # Fallback
+      true ->
+        "Any"
+    end
+  end
+
+  defp build_type_name(module) do
+    module |> Module.split() |> List.last()
+  end
+end
+```
+
+## Step 3: Code Generation
+
+Generate types and RPC functions:
+
+```elixir
+defmodule AshKotlin.Codegen.Generator do
+  alias AshIntrospection.Codegen.{TypeDiscovery, ActionIntrospection}
+  alias AshKotlin.Codegen.TypeMapper
+
+  def generate(domain, rpc_config) do
+    # Discover all types
+    {:ok, resources} = TypeDiscovery.scan_rpc_resources(rpc_config.resources, domain)
+    embedded = TypeDiscovery.find_embedded_resources(resources, domain)
+
+    # Generate data classes
+    type_definitions = Enum.map(embedded, &generate_data_class/1)
+
+    # Generate RPC functions
+    rpc_functions = Enum.flat_map(rpc_config.resources, fn {resource, actions} ->
+      Enum.map(actions, fn action_config ->
+        action = Ash.Resource.Info.action(resource, action_config.action)
+        generate_rpc_function(resource, action, action_config)
+      end)
+    end)
+
+    combine_output(type_definitions, rpc_functions)
+  end
+
+  defp generate_data_class(resource) do
+    attrs = Ash.Resource.Info.public_attributes(resource)
+    name = TypeMapper.build_type_name(resource)
+
+    fields = Enum.map(attrs, fn attr ->
+      type = TypeMapper.map_type(attr.type, attr.constraints)
+      nullable = if attr.allow_nil?, do: "?", else: ""
+      "  val #{to_camel_case(attr.name)}: #{type}#{nullable}"
+    end)
+
+    """
+    data class #{name}(
+    #{Enum.join(fields, ",\n")}
+    )
+    """
+  end
+
+  defp generate_rpc_function(resource, action, config) do
+    name = config.name
+    input_type = ActionIntrospection.action_input_type(resource, action)
+
+    # Generate based on action type and input requirements
+    # ...
+  end
+end
+```
+
+## Step 4: RPC Runtime
+
+Create your language-specific RPC pipeline wrapper:
+
+```elixir
+defmodule AshKotlin.Rpc.Pipeline do
+  alias AshIntrospection.Rpc.{Pipeline, Request, Errors}
+  alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
+
+  @config %{
+    input_field_formatter: :camel_case,
+    output_field_formatter: :camel_case,
+    field_names_callback: :interop_field_names,
+    not_found_error?: true
+  }
+
+  def execute(params, opts \\ []) do
+    with {:ok, request} <- parse_request(params, opts),
+         {:ok, result} <- Pipeline.execute_ash_action(request, @config),
+         {:ok, processed} <- Pipeline.process_result(result, request, @config) do
+      formatted = Pipeline.format_output_with_request(processed, request, @config)
+      {:ok, %{success: true, data: formatted}}
+    else
+      {:error, error} ->
+        errors = Errors.to_errors(error, request, @config)
+        {:ok, %{success: false, errors: errors}}
+    end
+  end
+
+  defp parse_request(params, opts) do
+    # Stage 1: Parse and validate input
+    # This is language-specific!
+
+    with {:ok, {domain, resource, action}} <- discover_action(params),
+         {:ok, input} <- parse_input(params, resource, action),
+         {:ok, fields} <- parse_fields(params, resource, action) do
+
+      # Process field selection
+      {:ok, {select, load, template}} =
+        FieldSelector.process(fields, resource, action, @config)
+
+      request = %Request{
+        domain: domain,
+        resource: resource,
+        action: action,
+        input: input,
+        select: select,
+        load: load,
+        extraction_template: template,
+        actor: opts[:actor],
+        tenant: opts[:tenant]
+      }
+
+      {:ok, request}
+    end
+  end
+end
+```
+
+## Step 5: DSL Extension (Optional)
+
+Add a Spark DSL for configuration:
+
+```elixir
+defmodule AshKotlin.Rpc do
+  use Spark.Dsl.Extension
+
+  @sections [
+    %Spark.Dsl.Section{
+      name: :kotlin_rpc,
+      entities: [
+        %Spark.Dsl.Entity{
+          name: :resource,
+          args: [:resource],
+          schema: [
+            resource: [type: :atom, required: true]
+          ],
+          entities: [
+            %Spark.Dsl.Entity{
+              name: :rpc_action,
+              args: [:name, :action],
+              schema: [
+                name: [type: :atom, required: true],
+                action: [type: :atom, required: true],
+                identities: [type: {:list, :atom}, default: [:_primary_key]]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+end
+```
+
+## Common Pitfalls
+
+### 1. NewType Unwrapping
+
+Always unwrap NewTypes before type classification:
+
+```elixir
+# WRONG - May fail for NewTypes
+if Introspection.is_embedded_resource?(type), do: ...
+
+# CORRECT - Unwrap first
+{unwrapped, constraints} = Introspection.unwrap_new_type(type, constraints)
+if Introspection.is_embedded_resource?(unwrapped), do: ...
+```
+
+### 2. Field Name Callback Precedence
+
+Check language-specific callbacks before falling back:
+
+```elixir
+# Check typescript_field_names first, then interop_field_names
+field_names = cond do
+  function_exported?(module, :kotlin_field_names, 0) ->
+    module.kotlin_field_names()
+  Introspection.has_interop_field_names?(module) ->
+    Introspection.get_interop_field_names_map(module)
+  true ->
+    %{}
+end
+```
+
+### 3. Constraint Preservation
+
+When processing types, preserve constraints through the pipeline:
+
+```elixir
+# Constraints contain important type information
+{type, constraints} = Introspection.unwrap_new_type(attr.type, attr.constraints)
+
+# Pass constraints to child processors
+inner_constraints = Keyword.get(constraints, :items, [])
+process_inner_type(inner_type, inner_constraints)
+```
+
+### 4. Cycle Detection in Type Discovery
+
+Always track visited types to prevent infinite loops:
+
+```elixir
+defp traverse_types(types, visited \\ MapSet.new()) do
+  Enum.flat_map(types, fn type ->
+    if MapSet.member?(visited, type) do
+      []  # Already visited, skip
+    else
+      visited = MapSet.put(visited, type)
+      [type | traverse_types(get_nested_types(type), visited)]
+    end
+  end)
+end
+```
+
+### 5. Identity Handling for Updates/Deletes
+
+Support multiple identity types:
+
+```elixir
+# Primary key (simple value)
+identity: "uuid-123"
+
+# Primary key (composite)
+identity: %{org_id: "org-1", user_id: "user-1"}
+
+# Named identity
+identity: %{email: "user@example.com"}
+```
+
+### 6. Pagination Response Handling
+
+Handle both paginated and non-paginated responses:
+
+```elixir
+case result do
+  %Ash.Page.Offset{results: results, count: count} ->
+    %{results: process_results(results), count: count}
+
+  %Ash.Page.Keyset{results: results} ->
+    %{results: process_results(results)}
+
+  results when is_list(results) ->
+    process_results(results)
+
+  single_result ->
+    process_result(single_result)
+end
+```
+
+### 7. Error Field Path Formatting
+
+Convert field paths to client format:
+
+```elixir
+# Ash returns: [:user, :address, :street]
+# Client expects: ["user", "address", "street"] with camelCase
+path = Enum.map(error.path, fn
+  field when is_atom(field) -> to_camel_case(field)
+  index when is_integer(index) -> Integer.to_string(index)
+end)
+```
+
+### 8. Generic Action Return Types
+
+Not all generic actions return field-selectable types:
+
+```elixir
+case ActionIntrospection.action_returns_field_selectable_type?(action) do
+  {:ok, :resource, module} ->
+    # Can select fields, generate typed response
+    generate_typed_response(module)
+
+  {:ok, :typed_map, fields} ->
+    # Can select fields from inline type
+    generate_inline_response(fields)
+
+  {:error, :not_field_selectable_type} ->
+    # Returns primitive, no field selection
+    generate_primitive_response(action.returns)
+
+  {:error, :not_generic_action} ->
+    # Not a generic action, use standard CRUD handling
+    handle_crud_action(action)
+end
+```
+
+## Requirements
+
+- Elixir 1.15 or later
+- Ash 3.0 or later
+
+## Contributing
+
+Contributions are welcome! Please:
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes with tests
+4. Ensure all tests pass (`mix test`)
+5. Run code formatter (`mix format`)
+6. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Support
+
+- **Documentation**: [https://hexdocs.pm/ash_introspection](https://hexdocs.pm/ash_introspection)
+- **GitHub Issues**: [https://github.com/ash-project/ash_introspection/issues](https://github.com/ash-project/ash_introspection/issues)
+- **Discord**: [Ash Framework Discord](https://discord.gg/HTHRaaVPUc)

--- a/lib/ash_introspection.ex
+++ b/lib/ash_introspection.ex
@@ -6,39 +6,190 @@ defmodule AshIntrospection do
   @moduledoc """
   Shared core library for Ash interoperability with multiple languages.
 
-  This library provides the foundational modules used by language-specific
-  generators like `AshTypescript` and `AshKotlinMultiplatform`.
+  AshIntrospection provides the foundational modules used by language-specific
+  generators like `AshTypescript` and `AshKotlinMultiplatform`. It enables
+  seamless RPC communication between Elixir/Ash backends and clients in other
+  languages through:
 
-  ## Type System
+  - **Unified type introspection** - Consistent type classification and analysis
+  - **Language-agnostic RPC pipeline** - Execute Ash actions with field selection
+  - **Bidirectional field name mapping** - Convert between snake_case and camelCase
+  - **Type-driven value formatting** - Format values based on their Ash types
+  - **Comprehensive error handling** - Standardized error responses
 
-  - `AshIntrospection.TypeSystem.Introspection` - Centralized type classification
-  - `AshIntrospection.TypeSystem.ResourceFields` - Resource field lookup
+  ## Architecture Overview
 
-  ## RPC Runtime
+  ```
+  ┌─────────────────────────────────────────────────────────────┐
+  │           Language-Specific Generators                      │
+  │        (AshTypescript, AshKotlinMultiplatform)             │
+  └────────────────────┬────────────────────────────────────────┘
+                       │ delegates to
+                       ▼
+  ┌─────────────────────────────────────────────────────────────┐
+  │         AshIntrospection (Shared Core Library)             │
+  │                                                             │
+  │  ┌─────────────────────────────────────────────────────┐   │
+  │  │  Type System                                        │   │
+  │  │  • Introspection - Type classification & unwrap     │   │
+  │  │  • ResourceFields - Field type lookup               │   │
+  │  └─────────────────────────────────────────────────────┘   │
+  │                                                             │
+  │  ┌─────────────────────────────────────────────────────┐   │
+  │  │  RPC Pipeline (4-Stage)                             │   │
+  │  │  • Stage 1: Parse request (language-specific)       │   │
+  │  │  • Stage 2: Execute Ash action                      │   │
+  │  │  • Stage 3: Process result (extract fields)         │   │
+  │  │  • Stage 4: Format output (convert field names)     │   │
+  │  └─────────────────────────────────────────────────────┘   │
+  │                                                             │
+  │  ┌─────────────────────────────────────────────────────┐   │
+  │  │  Code Generation                                    │   │
+  │  │  • TypeDiscovery - Resource & type scanning         │   │
+  │  │  • ActionIntrospection - Action analysis            │   │
+  │  │  • ValidationErrorTypes - Error type classification │   │
+  │  └─────────────────────────────────────────────────────┘   │
+  └─────────────────────────────────────────────────────────────┘
+                       │
+                       ▼
+  ┌─────────────────────────────────────────────────────────────┐
+  │                    Ash Framework                            │
+  │          (Resources, Types, Queries, Changesets)           │
+  └─────────────────────────────────────────────────────────────┘
+  ```
 
-  - `AshIntrospection.Rpc.Request` - Request data structure for RPC pipeline
-  - `AshIntrospection.Rpc.Pipeline` - Language-agnostic 4-stage RPC pipeline
-  - `AshIntrospection.Rpc.ValueFormatter` - Bidirectional type-driven value formatting
-  - `AshIntrospection.Rpc.ResultProcessor` - Field extraction from results
-  - `AshIntrospection.Rpc.FieldExtractor` - Unified field extraction for data structures
-  - `AshIntrospection.Rpc.ErrorBuilder` - Comprehensive error handling
-  - `AshIntrospection.Rpc.Errors` - Central error processing
-  - `AshIntrospection.Rpc.Error` - Error protocol for custom error types
-  - `AshIntrospection.Rpc.DefaultErrorHandler` - Pass-through error handler
+  ## Module Categories
 
-  ## Field Processing
+  ### Type System
 
-  - `AshIntrospection.Rpc.FieldProcessing.Atomizer` - Field name atomization
-  - `AshIntrospection.Rpc.FieldProcessing.FieldSelector` - Type-driven field selection
-  - `AshIntrospection.Rpc.FieldProcessing.Validation` - Field validation helpers
+  Modules for analyzing and classifying Ash types:
 
-  ## Code Generation
+  - `AshIntrospection.TypeSystem.Introspection` - Core type classification,
+    NewType unwrapping, union type extraction, and field name callback detection
 
-  - `AshIntrospection.Codegen.TypeDiscovery` - Resource and type scanning
+  - `AshIntrospection.TypeSystem.ResourceFields` - Unified resource field lookup
+    for attributes, calculations, relationships, and aggregates
 
-  ## Formatting
+  ### RPC Runtime
 
-  - `AshIntrospection.FieldFormatter` - Field name transformation utilities
-  - `AshIntrospection.Helpers` - Case conversion utilities
+  Modules for executing Ash actions via RPC:
+
+  - `AshIntrospection.Rpc.Request` - Request data structure containing domain,
+    resource, action, input, field selection, and query parameters
+
+  - `AshIntrospection.Rpc.Pipeline` - Language-agnostic 4-stage pipeline that
+    executes actions, processes results, and formats output
+
+  - `AshIntrospection.Rpc.ValueFormatter` - Bidirectional type-driven value
+    formatting for input parsing and output generation
+
+  - `AshIntrospection.Rpc.ResultProcessor` - Field extraction from action results
+    using pre-computed extraction templates
+
+  - `AshIntrospection.Rpc.FieldExtractor` - Unified field extraction for maps,
+    structs, keyword lists, and tuples
+
+  ### Field Processing
+
+  Modules for handling field selection and validation:
+
+  - `AshIntrospection.Rpc.FieldProcessing.Atomizer` - Converts client field names
+    to atoms while preserving original strings for reverse mapping
+
+  - `AshIntrospection.Rpc.FieldProcessing.FieldSelector` - Type-driven recursive
+    field selection with validation for all composite types
+
+  - `AshIntrospection.Rpc.FieldProcessing.Validation` - Duplicate detection and
+    field existence validation
+
+  ### Error Handling
+
+  Modules for standardized error responses:
+
+  - `AshIntrospection.Rpc.Error` - Protocol for extracting information from
+    exceptions into standardized format
+
+  - `AshIntrospection.Rpc.ErrorBuilder` - Comprehensive error message generation
+    for all error types
+
+  - `AshIntrospection.Rpc.Errors` - Central error processing pipeline with
+    variable interpolation and custom handlers
+
+  - `AshIntrospection.Rpc.DefaultErrorHandler` - Pass-through handler for
+    unmodified error responses
+
+  ### Code Generation
+
+  Modules for type discovery and action analysis:
+
+  - `AshIntrospection.Codegen.TypeDiscovery` - Recursive scanning of resources
+    and types for code generation, with cycle detection and path tracking
+
+  - `AshIntrospection.Codegen.ActionIntrospection` - Analysis of action
+    characteristics including pagination, input requirements, and return types
+
+  - `AshIntrospection.Codegen.ValidationErrorTypes` - Language-agnostic
+    classification of validation error types for code generation
+
+  ### Formatting Utilities
+
+  Modules for field name transformation:
+
+  - `AshIntrospection.FieldFormatter` - Field name formatting with built-in
+    formatters (camelCase, PascalCase, snake_case) and custom formatter support
+
+  - `AshIntrospection.Helpers` - Low-level case conversion utilities
+
+  ## Key Design Patterns
+
+  ### Type-Driven Dispatch
+
+  Many modules use a unified dispatch pattern based on `{type, constraints}` tuples.
+  This makes types self-describing and enables consistent handling across:
+
+  - `ValueFormatter` - Format values for input/output
+  - `ResultProcessor` - Extract fields from results
+  - `FieldSelector` - Validate field selections
+  - `ValidationErrorTypes` - Classify error types
+
+  ### Configuration via Maps
+
+  The RPC pipeline accepts configuration maps for language-specific behavior:
+
+  ```elixir
+  %{
+    input_field_formatter: :camel_case,
+    output_field_formatter: :camel_case,
+    field_names_callback: :interop_field_names,
+    get_original_field_name: fn resource, client_key -> ... end,
+    format_field_for_client: fn field_name, resource, formatter -> ... end,
+    not_found_error?: true
+  }
+  ```
+
+  ### Field Name Callbacks
+
+  Types can define callbacks for field name mapping:
+
+  - `interop_field_names/0` - Generalized callback for all languages
+  - `typescript_field_names/0` - TypeScript-specific (falls back to interop)
+  - `interop_type_name/0` - Custom type name for code generation
+
+  ## Installation
+
+  Add to your `mix.exs`:
+
+  ```elixir
+  def deps do
+    [
+      {:ash_introspection, "~> 0.2"}
+    ]
+  end
+  ```
+
+  ## Usage
+
+  This library is primarily used as a dependency by language-specific generators.
+  See the documentation for each module for direct usage patterns.
   """
 end

--- a/lib/ash_introspection/codegen/action_introspection.ex
+++ b/lib/ash_introspection/codegen/action_introspection.ex
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors <https://github.com/ash-project/ash_introspection/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Codegen.ActionIntrospection do
+  @moduledoc """
+  Provides helper functions for analyzing Ash actions.
+
+  This module contains utilities for determining action characteristics like:
+  - Pagination support (offset, keyset, required, countable)
+  - Input requirements
+  - Return type field selectability
+
+  The return type analysis uses a type-driven classification pattern with
+  `classify_return_type/2` for consistent handling of all type variants.
+  """
+
+  # Container types that can have field constraints for field selection
+  @field_constrained_types [Ash.Type.Map, Ash.Type.Keyword, Ash.Type.Tuple]
+
+  # ─────────────────────────────────────────────────────────────────
+  # Pagination Helpers
+  # ─────────────────────────────────────────────────────────────────
+
+  @doc """
+  Returns true if the action supports pagination.
+
+  ## Examples
+
+      iex> action_supports_pagination?(%{type: :read, get?: false, pagination: %{offset?: true}})
+      true
+
+      iex> action_supports_pagination?(%{type: :read, get?: true})
+      false
+  """
+  def action_supports_pagination?(action) do
+    action.type == :read and not action.get? and has_pagination_config?(action)
+  end
+
+  @doc """
+  Returns true if the action supports offset-based pagination.
+  """
+  def action_supports_offset_pagination?(action) do
+    case get_pagination_config(action) do
+      nil -> false
+      pagination_config -> Map.get(pagination_config, :offset?, false)
+    end
+  end
+
+  @doc """
+  Returns true if the action supports keyset-based pagination.
+  """
+  def action_supports_keyset_pagination?(action) do
+    case get_pagination_config(action) do
+      nil -> false
+      pagination_config -> Map.get(pagination_config, :keyset?, false)
+    end
+  end
+
+  @doc """
+  Returns true if the action requires pagination.
+  """
+  def action_requires_pagination?(action) do
+    case get_pagination_config(action) do
+      nil -> false
+      pagination_config -> Map.get(pagination_config, :required?, false)
+    end
+  end
+
+  @doc """
+  Returns true if the action supports countable pagination.
+  """
+  def action_supports_countable?(action) do
+    case get_pagination_config(action) do
+      nil -> false
+      pagination_config -> Map.get(pagination_config, :countable, false)
+    end
+  end
+
+  @doc """
+  Returns true if the action has a default limit configured.
+  """
+  def action_has_default_limit?(action) do
+    case get_pagination_config(action) do
+      nil -> false
+      pagination_config -> Map.has_key?(pagination_config, :default_limit)
+    end
+  end
+
+  @doc """
+  Returns the default limit for the action, or nil if not configured.
+  """
+  def get_default_limit(action) do
+    case get_pagination_config(action) do
+      nil -> nil
+      pagination_config -> Map.get(pagination_config, :default_limit)
+    end
+  end
+
+  @doc """
+  Returns the max page size for the action, or nil if not configured.
+  """
+  def get_max_page_size(action) do
+    case get_pagination_config(action) do
+      nil -> nil
+      pagination_config -> Map.get(pagination_config, :max_page_size)
+    end
+  end
+
+  @doc """
+  Returns true if the action has pagination configuration.
+  """
+  def has_pagination_config?(action) do
+    case action do
+      %{pagination: pagination} when is_map(pagination) -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Gets the pagination configuration for an action.
+  """
+  def get_pagination_config(action) do
+    case action do
+      %{pagination: pagination} when is_map(pagination) -> pagination
+      _ -> nil
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Input Type Analysis
+  # ─────────────────────────────────────────────────────────────────
+
+  @doc """
+  Returns :required | :optional | :none
+
+  Determines whether an action requires input, has optional input, or has no input.
+  This is based on the action's public arguments and accepted attributes.
+  """
+  def action_input_type(resource, action) do
+    # Get public arguments
+    public_arguments = Enum.filter(action.arguments, & &1.public?)
+
+    # Get accepted attributes (for create/update/destroy actions)
+    accepted_attributes =
+      (Map.get(action, :accept) || [])
+      |> Enum.map(&Ash.Resource.Info.attribute(resource, &1))
+      |> Enum.reject(&is_nil/1)
+
+    inputs = public_arguments ++ accepted_attributes
+
+    cond do
+      Enum.empty?(inputs) ->
+        :none
+
+      Enum.any?(inputs, fn
+        %Ash.Resource.Actions.Argument{} = input ->
+          not input.allow_nil? and is_nil(input.default)
+
+        %Ash.Resource.Attribute{} = input ->
+          input.name not in Map.get(action, :allow_nil_input, []) and
+              (input.name in Map.get(action, :require_attributes, []) ||
+                 (not input.allow_nil? and is_nil(input.default)))
+      end) ->
+        :required
+
+      true ->
+        :optional
+    end
+  end
+
+  @doc """
+  Returns the list of required input fields for an action.
+
+  This returns the field names that must be provided (non-nil, no default).
+  """
+  def get_required_inputs(resource, action) do
+    # Get public arguments
+    public_arguments = Enum.filter(action.arguments, & &1.public?)
+
+    # Get accepted attributes (for create/update/destroy actions)
+    accepted_attributes =
+      (Map.get(action, :accept) || [])
+      |> Enum.map(&Ash.Resource.Info.attribute(resource, &1))
+      |> Enum.reject(&is_nil/1)
+
+    inputs = public_arguments ++ accepted_attributes
+
+    Enum.filter(inputs, fn
+      %Ash.Resource.Actions.Argument{} = input ->
+        not input.allow_nil? and is_nil(input.default)
+
+      %Ash.Resource.Attribute{} = input ->
+        input.name not in Map.get(action, :allow_nil_input, []) and
+            (input.name in Map.get(action, :require_attributes, []) ||
+               (not input.allow_nil? and is_nil(input.default)))
+    end)
+    |> Enum.map(& &1.name)
+  end
+
+  @doc """
+  Returns the list of optional input fields for an action.
+
+  This returns the field names that can be provided but are not required.
+  """
+  def get_optional_inputs(resource, action) do
+    # Get public arguments
+    public_arguments = Enum.filter(action.arguments, & &1.public?)
+
+    # Get accepted attributes (for create/update/destroy actions)
+    accepted_attributes =
+      (Map.get(action, :accept) || [])
+      |> Enum.map(&Ash.Resource.Info.attribute(resource, &1))
+      |> Enum.reject(&is_nil/1)
+
+    inputs = public_arguments ++ accepted_attributes
+
+    Enum.reject(inputs, fn
+      %Ash.Resource.Actions.Argument{} = input ->
+        not input.allow_nil? and is_nil(input.default)
+
+      %Ash.Resource.Attribute{} = input ->
+        input.name not in Map.get(action, :allow_nil_input, []) and
+            (input.name in Map.get(action, :require_attributes, []) ||
+               (not input.allow_nil? and is_nil(input.default)))
+    end)
+    |> Enum.map(& &1.name)
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Return Type Analysis
+  # ─────────────────────────────────────────────────────────────────
+
+  @doc """
+  Checks if a generic action returns a field-selectable type.
+
+  Returns:
+  - `{:ok, :resource, resource_module}` - Single resource
+  - `{:ok, :array_of_resource, resource_module}` - Array of resources
+  - `{:ok, :typed_map, fields}` - Typed map with constraints
+  - `{:ok, :array_of_typed_map, fields}` - Array of typed maps
+  - `{:ok, :typed_struct, {module, fields}}` - Type with field constraints (TypedStruct or similar)
+  - `{:ok, :array_of_typed_struct, {module, fields}}` - Array of types with field constraints
+  - `{:ok, :unconstrained_map, nil}` - Map without field constraints
+  - `{:error, :not_generic_action}` - Not a generic action
+  - `{:error, reason}` - Other errors
+  """
+  def action_returns_field_selectable_type?(action) do
+    if action.type != :action do
+      {:error, :not_generic_action}
+    else
+      check_action_returns(action)
+    end
+  end
+
+  @doc """
+  Returns true if the action returns a type that supports field selection.
+
+  This is a convenience wrapper that returns a boolean.
+  """
+  def action_supports_field_selection?(action) do
+    case action_returns_field_selectable_type?(action) do
+      {:ok, _type, _data} -> true
+      {:error, _} -> false
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Return Type Classification
+  # ─────────────────────────────────────────────────────────────────
+
+  defp check_action_returns(action) do
+    {base_type, constraints, is_array} = unwrap_return_type(action)
+
+    case classify_return_type(base_type, constraints) do
+      {:resource, module} ->
+        if is_array do
+          {:ok, :array_of_resource, module}
+        else
+          {:ok, :resource, module}
+        end
+
+      {:typed_map, fields} ->
+        if is_array do
+          {:ok, :array_of_typed_map, fields}
+        else
+          {:ok, :typed_map, fields}
+        end
+
+      {:typed_struct, {module, fields}} ->
+        if is_array do
+          {:ok, :array_of_typed_struct, {module, fields}}
+        else
+          {:ok, :typed_struct, {module, fields}}
+        end
+
+      :unconstrained_map ->
+        {:ok, :unconstrained_map, nil}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  # Unwraps array wrapper from return type, returning {base_type, constraints, is_array}
+  defp unwrap_return_type(action) do
+    case action.returns do
+      {:array, inner_type} ->
+        inner_constraints = Keyword.get(action.constraints || [], :items, [])
+        {inner_type, inner_constraints, true}
+
+      type ->
+        {type, action.constraints || [], false}
+    end
+  end
+
+  # Classifies a return type into a category for field selectability
+  @spec classify_return_type(atom() | tuple(), keyword()) ::
+          {:resource, module()}
+          | {:typed_map, keyword()}
+          | {:typed_struct, {module(), keyword()}}
+          | :unconstrained_map
+          | {:error, atom()}
+  defp classify_return_type(type, constraints) do
+    cond do
+      # Ash.Type.Struct with instance_of - represents a resource
+      type == Ash.Type.Struct and Keyword.has_key?(constraints, :instance_of) ->
+        {:resource, Keyword.get(constraints, :instance_of)}
+
+      # Ash.Type.Struct without instance_of - error
+      type == Ash.Type.Struct ->
+        {:error, :no_instance_of_defined}
+
+      # Container types with field constraints (Map, Keyword, Tuple)
+      type in @field_constrained_types and Keyword.has_key?(constraints, :fields) ->
+        {:typed_map, Keyword.get(constraints, :fields)}
+
+      # Container types without field constraints - unconstrained map
+      type in @field_constrained_types ->
+        :unconstrained_map
+
+      # Module with field constraints (TypedStruct pattern - requires both fields and instance_of)
+      is_atom(type) and has_field_constraints?(constraints) ->
+        fields = Keyword.get(constraints, :fields, [])
+        {:typed_struct, {type, fields}}
+
+      # Not field-selectable
+      true ->
+        {:error, :not_field_selectable_type}
+    end
+  end
+
+  defp has_field_constraints?(constraints) do
+    Keyword.has_key?(constraints, :fields) and Keyword.has_key?(constraints, :instance_of)
+  end
+end

--- a/lib/ash_introspection/codegen/validation_error_types.ex
+++ b/lib/ash_introspection/codegen/validation_error_types.ex
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors <https://github.com/ash-project/ash_introspection/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Codegen.ValidationErrorTypes do
+  @moduledoc """
+  Provides language-agnostic classification of validation error types for Ash types.
+
+  This module uses a unified type-driven dispatch pattern for classifying Ash types
+  into their corresponding validation error type categories. Language-specific
+  generators (TypeScript, Kotlin, etc.) can use this classification to generate
+  appropriate error type definitions.
+
+  ## Error Type Categories
+
+  The module classifies types into the following error categories:
+
+  - `:primitive_errors` - Simple string error messages (for strings, integers, etc.)
+  - `:array_errors` - Array of inner error type
+  - `:resource_errors` - Validation errors for an Ash resource
+  - `:typed_container_errors` - Errors for a map/struct with field constraints
+  - `:union_errors` - Errors for union type members
+  - `:custom_type_errors` - Errors for custom types with interop_type_name callback
+  - `:unconstrained_map_errors` - Generic record/map errors
+
+  ## Usage
+
+  ```elixir
+  # Classify a type
+  {:ok, classification} = classify_error_type(Ash.Type.String, [])
+  # => {:ok, {:primitive_errors, nil}}
+
+  # Classify an embedded resource
+  {:ok, classification} = classify_error_type(Ash.Type.Struct, [instance_of: MyEmbeddedResource])
+  # => {:ok, {:resource_errors, MyEmbeddedResource}}
+
+  # Classify an array of resources
+  {:ok, classification} = classify_error_type({:array, Ash.Type.Struct}, [items: [instance_of: MyResource]])
+  # => {:ok, {:array_errors, {:resource_errors, MyResource}}}
+  ```
+  """
+
+  alias AshIntrospection.TypeSystem.Introspection
+
+  # ─────────────────────────────────────────────────────────────────
+  # Core Type Classification
+  # ─────────────────────────────────────────────────────────────────
+
+  @doc """
+  Classifies an Ash type into its corresponding validation error type category.
+
+  This is the unified dispatcher that handles all type-to-error-type classifications.
+  NewTypes are unwrapped at entry for consistent handling.
+
+  ## Parameters
+  - `type` - The Ash type (atom, tuple, or module)
+  - `constraints` - Type constraints (keyword list)
+
+  ## Returns
+  `{:ok, classification}` where classification is one of:
+  - `{:primitive_errors, nil}` - Simple string errors
+  - `{:array_errors, inner_classification}` - Array with inner error type
+  - `{:resource_errors, resource_module}` - Resource validation errors
+  - `{:typed_container_errors, field_classifications}` - Container with field errors
+  - `{:union_errors, member_classifications}` - Union member errors
+  - `{:custom_type_errors, type_module}` - Custom type with interop_type_name
+  - `{:unconstrained_map_errors, nil}` - Generic map errors
+  """
+  @spec classify_error_type(atom() | tuple(), keyword()) ::
+          {:ok,
+           {:primitive_errors, nil}
+           | {:array_errors, term()}
+           | {:resource_errors, module()}
+           | {:typed_container_errors, list()}
+           | {:union_errors, list()}
+           | {:custom_type_errors, module()}
+           | {:unconstrained_map_errors, nil}}
+  def classify_error_type(type, constraints \\ [])
+
+  # Handle nil type
+  def classify_error_type(nil, _constraints), do: {:ok, {:primitive_errors, nil}}
+
+  def classify_error_type(type, constraints) do
+    # Unwrap NewTypes FIRST (consistent with ValueFormatter pattern)
+    {unwrapped_type, full_constraints} = Introspection.unwrap_new_type(type, constraints)
+
+    classification =
+      cond do
+        # Arrays - recurse into inner type
+        match?({:array, _}, type) ->
+          {:array, inner_type} = type
+          inner_constraints = Keyword.get(constraints, :items, [])
+          {:ok, inner_classification} = classify_error_type(inner_type, inner_constraints)
+          {:array_errors, inner_classification}
+
+        # Custom types with interop_type_name (check before embedded resource)
+        Introspection.is_custom_interop_type?(unwrapped_type) ->
+          {:custom_type_errors, unwrapped_type}
+
+        # Embedded resources
+        Introspection.is_embedded_resource?(unwrapped_type) ->
+          {:resource_errors, unwrapped_type}
+
+        # Union types
+        unwrapped_type == Ash.Type.Union ->
+          union_types = Introspection.get_union_types_from_constraints(unwrapped_type, full_constraints)
+          member_classifications = classify_union_members(union_types)
+          {:union_errors, member_classifications}
+
+        # Typed containers (Map, Keyword, Tuple) with potential field constraints
+        unwrapped_type in [Ash.Type.Map, Ash.Type.Keyword, Ash.Type.Tuple] ->
+          classify_typed_container(full_constraints)
+
+        # Ash.Type.Struct - check for instance_of
+        unwrapped_type == Ash.Type.Struct ->
+          classify_struct_type(full_constraints)
+
+        # Types with fields and instance_of (TypedStruct pattern via NewType)
+        Keyword.has_key?(full_constraints, :fields) and
+            Keyword.has_key?(full_constraints, :instance_of) ->
+          instance_of = Keyword.get(full_constraints, :instance_of)
+          {:resource_errors, instance_of}
+
+        # Enum types - just primitive errors
+        Spark.implements_behaviour?(unwrapped_type, Ash.Type.Enum) ->
+          {:primitive_errors, nil}
+
+        # All primitives and unknown types
+        true ->
+          {:primitive_errors, nil}
+      end
+
+    {:ok, classification}
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Type-Specific Classifiers
+  # ─────────────────────────────────────────────────────────────────
+
+  defp classify_struct_type(constraints) do
+    instance_of = Keyword.get(constraints, :instance_of)
+
+    cond do
+      # instance_of pointing to embedded resource
+      instance_of && Introspection.is_embedded_resource?(instance_of) ->
+        {:resource_errors, instance_of}
+
+      # instance_of pointing to module with interop_type_name
+      instance_of && Introspection.is_custom_interop_type?(instance_of) ->
+        {:custom_type_errors, instance_of}
+
+      # Has fields constraint - typed container
+      Keyword.has_key?(constraints, :fields) ->
+        classify_typed_container(constraints)
+
+      # Fallback - unconstrained map
+      true ->
+        {:unconstrained_map_errors, nil}
+    end
+  end
+
+  defp classify_typed_container(constraints) do
+    fields = Keyword.get(constraints, :fields, [])
+
+    if fields == [] do
+      {:unconstrained_map_errors, nil}
+    else
+      field_classifications =
+        Enum.map(fields, fn {field_name, field_config} ->
+          field_type = Keyword.get(field_config, :type)
+          field_constraints = Keyword.get(field_config, :constraints, [])
+          {:ok, field_classification} = classify_error_type(field_type, field_constraints)
+
+          {field_name, field_classification}
+        end)
+
+      {:typed_container_errors, field_classifications}
+    end
+  end
+
+  defp classify_union_members(union_types) do
+    Enum.map(union_types, fn {type_name, type_config} ->
+      member_type = Keyword.get(type_config, :type)
+      member_constraints = Keyword.get(type_config, :constraints, [])
+      {:ok, member_classification} = classify_error_type(member_type, member_constraints)
+
+      {type_name, member_classification}
+    end)
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Action Error Type Analysis
+  # ─────────────────────────────────────────────────────────────────
+
+  @doc """
+  Returns the list of input fields for an action with their error type classifications.
+
+  This is useful for generating validation error types for action inputs.
+
+  ## Parameters
+  - `resource` - The Ash resource module
+  - `action` - The action struct
+
+  ## Returns
+  A list of `{field_name, classification, field_struct}` tuples, or empty list if no inputs.
+  """
+  def classify_action_input_errors(resource, action) do
+    # Get public arguments
+    public_arguments = Enum.filter(action.arguments, & &1.public?)
+
+    # Get accepted attributes (for create/update/destroy actions)
+    accepted_attributes =
+      (Map.get(action, :accept) || [])
+      |> Enum.map(&Ash.Resource.Info.attribute(resource, &1))
+      |> Enum.reject(&is_nil/1)
+
+    inputs = public_arguments ++ accepted_attributes
+
+    Enum.map(inputs, fn input ->
+      {:ok, classification} = classify_error_type(input.type, input.constraints || [])
+      {input.name, classification, input}
+    end)
+  end
+
+  @doc """
+  Returns error type classifications for all public attributes of a resource.
+
+  This is useful for generating validation error types for embedded resources.
+
+  ## Parameters
+  - `resource` - The Ash resource module
+
+  ## Returns
+  A list of `{field_name, classification, attribute_struct}` tuples.
+  """
+  def classify_resource_attribute_errors(resource) do
+    resource
+    |> Ash.Resource.Info.public_attributes()
+    |> Enum.map(fn attr ->
+      {:ok, classification} = classify_error_type(attr.type, attr.constraints || [])
+      {attr.name, classification, attr}
+    end)
+  end
+
+  @doc """
+  Returns error type classifications for fields in a typed struct/container.
+
+  ## Parameters
+  - `fields` - Keyword list of field definitions from type constraints
+
+  ## Returns
+  A list of `{field_name, classification}` tuples.
+  """
+  def classify_field_errors(fields) when is_list(fields) do
+    Enum.map(fields, fn {field_name, field_config} ->
+      field_type = Keyword.get(field_config, :type)
+      field_constraints = Keyword.get(field_config, :constraints, [])
+      {:ok, classification} = classify_error_type(field_type, field_constraints)
+
+      {field_name, classification}
+    end)
+  end
+end

--- a/test/ash_introspection/codegen/action_introspection_test.exs
+++ b/test/ash_introspection/codegen/action_introspection_test.exs
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Codegen.ActionIntrospectionTest do
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Codegen.ActionIntrospection
+  alias AshIntrospection.Test.Post
+
+  # Helper to get action from resource
+  defp get_action(action_name) do
+    Ash.Resource.Info.action(Post, action_name)
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Pagination Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "action_supports_pagination?/1" do
+    test "returns true for read actions with pagination config" do
+      assert ActionIntrospection.action_supports_pagination?(get_action(:list_offset))
+      assert ActionIntrospection.action_supports_pagination?(get_action(:list_keyset))
+      assert ActionIntrospection.action_supports_pagination?(get_action(:list_required))
+      assert ActionIntrospection.action_supports_pagination?(get_action(:list_hybrid))
+    end
+
+    test "returns false for read actions without pagination" do
+      refute ActionIntrospection.action_supports_pagination?(get_action(:read))
+    end
+
+    test "returns false for get actions even with arguments" do
+      refute ActionIntrospection.action_supports_pagination?(get_action(:get_by_id))
+    end
+
+    test "returns false for non-read actions" do
+      refute ActionIntrospection.action_supports_pagination?(get_action(:create))
+      refute ActionIntrospection.action_supports_pagination?(get_action(:update))
+      refute ActionIntrospection.action_supports_pagination?(get_action(:destroy))
+    end
+  end
+
+  describe "action_supports_offset_pagination?/1" do
+    test "returns true for offset-enabled actions" do
+      assert ActionIntrospection.action_supports_offset_pagination?(get_action(:list_offset))
+      assert ActionIntrospection.action_supports_offset_pagination?(get_action(:list_required))
+      assert ActionIntrospection.action_supports_offset_pagination?(get_action(:list_hybrid))
+    end
+
+    test "returns false for keyset-only actions" do
+      refute ActionIntrospection.action_supports_offset_pagination?(get_action(:list_keyset))
+    end
+
+    test "returns false for non-paginated actions" do
+      refute ActionIntrospection.action_supports_offset_pagination?(get_action(:read))
+    end
+  end
+
+  describe "action_supports_keyset_pagination?/1" do
+    test "returns true for keyset-enabled actions" do
+      assert ActionIntrospection.action_supports_keyset_pagination?(get_action(:list_keyset))
+      assert ActionIntrospection.action_supports_keyset_pagination?(get_action(:list_hybrid))
+    end
+
+    test "returns false for offset-only actions" do
+      refute ActionIntrospection.action_supports_keyset_pagination?(get_action(:list_offset))
+    end
+
+    test "returns false for non-paginated actions" do
+      refute ActionIntrospection.action_supports_keyset_pagination?(get_action(:read))
+    end
+  end
+
+  describe "action_requires_pagination?/1" do
+    test "returns true for required pagination actions" do
+      # Ash defaults required? to true for pagination
+      assert ActionIntrospection.action_requires_pagination?(get_action(:list_required))
+      assert ActionIntrospection.action_requires_pagination?(get_action(:list_offset))
+      assert ActionIntrospection.action_requires_pagination?(get_action(:list_keyset))
+    end
+
+    test "returns false for non-paginated actions" do
+      refute ActionIntrospection.action_requires_pagination?(get_action(:read))
+    end
+  end
+
+  describe "action_supports_countable?/1" do
+    test "returns true for countable actions" do
+      # Ash defaults countable to true for pagination
+      assert ActionIntrospection.action_supports_countable?(get_action(:list_offset))
+      assert ActionIntrospection.action_supports_countable?(get_action(:list_keyset))
+    end
+
+    test "returns false for non-paginated actions" do
+      refute ActionIntrospection.action_supports_countable?(get_action(:read))
+    end
+  end
+
+  describe "action_has_default_limit?/1" do
+    test "returns true for actions with default limit" do
+      assert ActionIntrospection.action_has_default_limit?(get_action(:list_offset))
+      assert ActionIntrospection.action_has_default_limit?(get_action(:list_keyset))
+    end
+
+    test "returns false for actions without default limit" do
+      refute ActionIntrospection.action_has_default_limit?(get_action(:read))
+    end
+  end
+
+  describe "get_default_limit/1" do
+    test "returns the default limit for paginated actions" do
+      assert ActionIntrospection.get_default_limit(get_action(:list_offset)) == 10
+      assert ActionIntrospection.get_default_limit(get_action(:list_keyset)) == 20
+      assert ActionIntrospection.get_default_limit(get_action(:list_required)) == 25
+      assert ActionIntrospection.get_default_limit(get_action(:list_hybrid)) == 15
+    end
+
+    test "returns nil for non-paginated actions" do
+      assert ActionIntrospection.get_default_limit(get_action(:read)) == nil
+    end
+  end
+
+  describe "get_max_page_size/1" do
+    test "returns the max page size when configured" do
+      assert ActionIntrospection.get_max_page_size(get_action(:list_offset)) == 100
+    end
+
+    test "returns default max page size when not explicitly configured" do
+      # Ash defaults max_page_size to 250
+      assert ActionIntrospection.get_max_page_size(get_action(:list_keyset)) == 250
+    end
+
+    test "returns nil for non-paginated actions" do
+      assert ActionIntrospection.get_max_page_size(get_action(:read)) == nil
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Input Type Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "action_input_type/2" do
+    test "returns :required for actions with required input" do
+      # create accepts title which has allow_nil?: false
+      assert ActionIntrospection.action_input_type(Post, get_action(:create)) == :required
+      # create_draft also accepts title which has allow_nil?: false
+      assert ActionIntrospection.action_input_type(Post, get_action(:create_draft)) == :required
+      # search has required query argument
+      assert ActionIntrospection.action_input_type(Post, get_action(:search)) == :required
+    end
+
+    test "returns :optional for actions with only optional input" do
+      # get_popular only has optional limit argument with a default
+      assert ActionIntrospection.action_input_type(Post, get_action(:get_popular)) == :optional
+    end
+
+    test "returns :none for actions with no input" do
+      assert ActionIntrospection.action_input_type(Post, get_action(:ping)) == :none
+      assert ActionIntrospection.action_input_type(Post, get_action(:get_stats)) == :none
+    end
+  end
+
+  describe "get_required_inputs/2" do
+    test "returns required field names for create actions" do
+      required = ActionIntrospection.get_required_inputs(Post, get_action(:create))
+      assert :title in required
+    end
+
+    test "returns required argument names for generic actions" do
+      required = ActionIntrospection.get_required_inputs(Post, get_action(:search))
+      assert :query in required
+      refute :limit in required
+    end
+
+    test "returns empty list for actions with no required inputs" do
+      assert ActionIntrospection.get_required_inputs(Post, get_action(:ping)) == []
+    end
+  end
+
+  describe "get_optional_inputs/2" do
+    test "returns optional field names" do
+      optional = ActionIntrospection.get_optional_inputs(Post, get_action(:create))
+      assert :body in optional
+      assert :published in optional
+    end
+
+    test "returns optional argument names" do
+      optional = ActionIntrospection.get_optional_inputs(Post, get_action(:search))
+      assert :limit in optional
+      refute :query in optional
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Return Type Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "action_returns_field_selectable_type?/1" do
+    test "returns error for non-generic actions" do
+      assert {:error, :not_generic_action} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:read))
+
+      assert {:error, :not_generic_action} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:create))
+    end
+
+    test "returns resource type for single resource return" do
+      assert {:ok, :resource, Post} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_featured))
+    end
+
+    test "returns array_of_resource for array of resources" do
+      assert {:ok, :array_of_resource, Post} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_popular))
+    end
+
+    test "returns typed_map for map with field constraints" do
+      result = ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_stats))
+      assert {:ok, :typed_map, fields} = result
+      assert Keyword.has_key?(fields, :total_posts)
+      assert Keyword.has_key?(fields, :published_count)
+      assert Keyword.has_key?(fields, :draft_count)
+    end
+
+    test "returns unconstrained_map for map without field constraints" do
+      assert {:ok, :unconstrained_map, nil} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_metadata))
+    end
+
+    test "returns error for primitive return types" do
+      assert {:error, :not_field_selectable_type} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_count))
+
+      assert {:error, :not_field_selectable_type} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:ping))
+    end
+  end
+
+  describe "action_supports_field_selection?/1" do
+    test "returns true for field-selectable returns" do
+      assert ActionIntrospection.action_supports_field_selection?(get_action(:get_featured))
+      assert ActionIntrospection.action_supports_field_selection?(get_action(:get_popular))
+      assert ActionIntrospection.action_supports_field_selection?(get_action(:get_stats))
+    end
+
+    test "returns false for primitive returns" do
+      refute ActionIntrospection.action_supports_field_selection?(get_action(:get_count))
+      refute ActionIntrospection.action_supports_field_selection?(get_action(:ping))
+    end
+
+    test "returns false for non-generic actions" do
+      refute ActionIntrospection.action_supports_field_selection?(get_action(:read))
+    end
+  end
+end

--- a/test/ash_introspection/codegen/validation_error_types_test.exs
+++ b/test/ash_introspection/codegen/validation_error_types_test.exs
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Codegen.ValidationErrorTypesTest do
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Codegen.ValidationErrorTypes
+  alias AshIntrospection.Test.{EmbeddedAddress, CustomType, Post, User}
+
+  # ─────────────────────────────────────────────────────────────────
+  # Basic Type Classification Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "classify_error_type/2 for primitives" do
+    test "classifies nil as primitive errors" do
+      assert {:ok, {:primitive_errors, nil}} = ValidationErrorTypes.classify_error_type(nil, [])
+    end
+
+    test "classifies string as primitive errors" do
+      assert {:ok, {:primitive_errors, nil}} =
+               ValidationErrorTypes.classify_error_type(:string, [])
+    end
+
+    test "classifies integer as primitive errors" do
+      assert {:ok, {:primitive_errors, nil}} =
+               ValidationErrorTypes.classify_error_type(:integer, [])
+    end
+
+    test "classifies boolean as primitive errors" do
+      assert {:ok, {:primitive_errors, nil}} =
+               ValidationErrorTypes.classify_error_type(:boolean, [])
+    end
+
+    test "classifies uuid as primitive errors" do
+      assert {:ok, {:primitive_errors, nil}} = ValidationErrorTypes.classify_error_type(:uuid, [])
+    end
+  end
+
+  describe "classify_error_type/2 for arrays" do
+    test "classifies array of primitives" do
+      assert {:ok, {:array_errors, {:primitive_errors, nil}}} =
+               ValidationErrorTypes.classify_error_type({:array, :string}, [])
+    end
+
+    test "classifies array of embedded resources" do
+      assert {:ok, {:array_errors, {:resource_errors, EmbeddedAddress}}} =
+               ValidationErrorTypes.classify_error_type(
+                 {:array, Ash.Type.Struct},
+                 items: [instance_of: EmbeddedAddress]
+               )
+    end
+
+    test "classifies nested arrays" do
+      assert {:ok, {:array_errors, {:array_errors, {:primitive_errors, nil}}}} =
+               ValidationErrorTypes.classify_error_type({:array, {:array, :string}}, [])
+    end
+  end
+
+  describe "classify_error_type/2 for embedded resources" do
+    test "classifies embedded resource via Ash.Type.Struct" do
+      assert {:ok, {:resource_errors, EmbeddedAddress}} =
+               ValidationErrorTypes.classify_error_type(
+                 Ash.Type.Struct,
+                 instance_of: EmbeddedAddress
+               )
+    end
+
+    test "classifies embedded resource module directly" do
+      assert {:ok, {:resource_errors, EmbeddedAddress}} =
+               ValidationErrorTypes.classify_error_type(EmbeddedAddress, [])
+    end
+  end
+
+  describe "classify_error_type/2 for custom types" do
+    test "classifies custom type with interop_type_name" do
+      assert {:ok, {:custom_type_errors, CustomType}} =
+               ValidationErrorTypes.classify_error_type(CustomType, [])
+    end
+  end
+
+  describe "classify_error_type/2 for typed containers" do
+    test "classifies map with field constraints" do
+      constraints = [
+        fields: [
+          name: [type: :string],
+          age: [type: :integer]
+        ]
+      ]
+
+      assert {:ok, {:typed_container_errors, field_classifications}} =
+               ValidationErrorTypes.classify_error_type(Ash.Type.Map, constraints)
+
+      assert {:name, {:primitive_errors, nil}} in field_classifications
+      assert {:age, {:primitive_errors, nil}} in field_classifications
+    end
+
+    test "classifies map without field constraints as unconstrained" do
+      assert {:ok, {:unconstrained_map_errors, nil}} =
+               ValidationErrorTypes.classify_error_type(Ash.Type.Map, [])
+    end
+
+    test "classifies keyword with field constraints" do
+      constraints = [
+        fields: [
+          key1: [type: :string],
+          key2: [type: :boolean]
+        ]
+      ]
+
+      assert {:ok, {:typed_container_errors, _}} =
+               ValidationErrorTypes.classify_error_type(Ash.Type.Keyword, constraints)
+    end
+
+    test "classifies tuple with field constraints" do
+      constraints = [
+        fields: [
+          first: [type: :string],
+          second: [type: :integer]
+        ]
+      ]
+
+      assert {:ok, {:typed_container_errors, _}} =
+               ValidationErrorTypes.classify_error_type(Ash.Type.Tuple, constraints)
+    end
+  end
+
+  describe "classify_error_type/2 for nested types" do
+    test "classifies typed container with embedded resource field" do
+      constraints = [
+        fields: [
+          name: [type: :string],
+          address: [type: Ash.Type.Struct, constraints: [instance_of: EmbeddedAddress]]
+        ]
+      ]
+
+      assert {:ok, {:typed_container_errors, field_classifications}} =
+               ValidationErrorTypes.classify_error_type(Ash.Type.Map, constraints)
+
+      assert {:name, {:primitive_errors, nil}} in field_classifications
+      assert {:address, {:resource_errors, EmbeddedAddress}} in field_classifications
+    end
+
+    test "classifies typed container with array field" do
+      constraints = [
+        fields: [
+          tags: [type: {:array, :string}]
+        ]
+      ]
+
+      assert {:ok, {:typed_container_errors, field_classifications}} =
+               ValidationErrorTypes.classify_error_type(Ash.Type.Map, constraints)
+
+      assert {:tags, {:array_errors, {:primitive_errors, nil}}} in field_classifications
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Action Input Error Classification Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "classify_action_input_errors/2" do
+    test "classifies create action inputs" do
+      action = Ash.Resource.Info.action(Post, :create)
+      classifications = ValidationErrorTypes.classify_action_input_errors(Post, action)
+
+      # Should include accepted attributes
+      field_names = Enum.map(classifications, fn {name, _, _} -> name end)
+      assert :title in field_names
+      assert :body in field_names
+      assert :published in field_names
+
+      # All should be primitive errors for this action
+      Enum.each(classifications, fn {_name, classification, _field} ->
+        assert {:primitive_errors, nil} = classification
+      end)
+    end
+
+    test "classifies generic action with arguments" do
+      action = Ash.Resource.Info.action(Post, :search)
+      classifications = ValidationErrorTypes.classify_action_input_errors(Post, action)
+
+      field_names = Enum.map(classifications, fn {name, _, _} -> name end)
+      assert :query in field_names
+      assert :limit in field_names
+    end
+
+    test "returns empty list for actions with no inputs" do
+      action = Ash.Resource.Info.action(Post, :ping)
+      assert [] = ValidationErrorTypes.classify_action_input_errors(Post, action)
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Resource Attribute Error Classification Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "classify_resource_attribute_errors/1" do
+    test "classifies all public attributes of a resource" do
+      classifications = ValidationErrorTypes.classify_resource_attribute_errors(EmbeddedAddress)
+
+      field_names = Enum.map(classifications, fn {name, _, _} -> name end)
+      assert :street in field_names
+      assert :city in field_names
+      assert :zip_code in field_names
+
+      # All should be primitive errors for this simple resource
+      Enum.each(classifications, fn {_name, classification, _attr} ->
+        assert {:primitive_errors, nil} = classification
+      end)
+    end
+
+    test "classifies user attributes with different types" do
+      classifications = ValidationErrorTypes.classify_resource_attribute_errors(User)
+
+      # Find the metadata field which is a map
+      metadata = Enum.find(classifications, fn {name, _, _} -> name == :metadata end)
+      assert {_, {:unconstrained_map_errors, nil}, _} = metadata
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────
+  # Field Error Classification Tests
+  # ─────────────────────────────────────────────────────────────────
+
+  describe "classify_field_errors/1" do
+    test "classifies simple field list" do
+      fields = [
+        name: [type: :string],
+        age: [type: :integer],
+        active: [type: :boolean]
+      ]
+
+      classifications = ValidationErrorTypes.classify_field_errors(fields)
+
+      assert {:name, {:primitive_errors, nil}} in classifications
+      assert {:age, {:primitive_errors, nil}} in classifications
+      assert {:active, {:primitive_errors, nil}} in classifications
+    end
+
+    test "classifies nested field types" do
+      fields = [
+        address: [type: Ash.Type.Struct, constraints: [instance_of: EmbeddedAddress]],
+        tags: [type: {:array, :string}]
+      ]
+
+      classifications = ValidationErrorTypes.classify_field_errors(fields)
+
+      assert {:address, {:resource_errors, EmbeddedAddress}} in classifications
+      assert {:tags, {:array_errors, {:primitive_errors, nil}}} in classifications
+    end
+  end
+end

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -124,3 +124,149 @@ defmodule AshIntrospection.Test.CustomType do
 
   def interop_type_name, do: "CustomString"
 end
+
+# ─────────────────────────────────────────────────────────────────
+# Test Resources for Action Introspection
+# ─────────────────────────────────────────────────────────────────
+
+defmodule AshIntrospection.Test.ActionDomain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource AshIntrospection.Test.Post
+  end
+end
+
+defmodule AshIntrospection.Test.Post do
+  @moduledoc """
+  A resource with various action configurations for testing action introspection.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.ActionDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, allow_nil?: false, public?: true
+    attribute :body, :string, public?: true
+    attribute :published, :boolean, default: false, public?: true
+    attribute :view_count, :integer, default: 0, public?: true
+  end
+
+  actions do
+    # Basic read with no pagination
+    read :read do
+      primary? true
+    end
+
+    # Read with offset pagination
+    read :list_offset do
+      pagination offset?: true, default_limit: 10, max_page_size: 100, countable: true
+    end
+
+    # Read with keyset pagination
+    read :list_keyset do
+      pagination keyset?: true, default_limit: 20
+    end
+
+    # Read with required pagination
+    read :list_required do
+      pagination offset?: true, required?: true, default_limit: 25
+    end
+
+    # Read with both pagination types
+    read :list_hybrid do
+      pagination offset?: true, keyset?: true, default_limit: 15
+    end
+
+    # Get action (not paginated)
+    read :get_by_id do
+      get? true
+      argument :id, :uuid, allow_nil?: false
+    end
+
+    # Create with required input
+    create :create do
+      accept [:title, :body, :published]
+    end
+
+    # Create with optional input
+    create :create_draft do
+      accept [:title, :body]
+      argument :tags, {:array, :string}, public?: true
+    end
+
+    # Update with optional input
+    update :update do
+      accept [:title, :body, :published]
+    end
+
+    # Destroy action
+    destroy :destroy
+
+    # Generic action returning a resource
+    action :get_featured, :struct do
+      constraints instance_of: AshIntrospection.Test.Post
+
+      run fn _input, _context ->
+        {:ok, nil}
+      end
+    end
+
+    # Generic action returning array of resources
+    action :get_popular, {:array, :struct} do
+      constraints items: [instance_of: AshIntrospection.Test.Post]
+      argument :limit, :integer, default: 10, public?: true
+
+      run fn _input, _context ->
+        {:ok, []}
+      end
+    end
+
+    # Generic action returning typed map
+    action :get_stats, :map do
+      constraints fields: [
+                    total_posts: [type: :integer],
+                    published_count: [type: :integer],
+                    draft_count: [type: :integer]
+                  ]
+
+      run fn _input, _context ->
+        {:ok, %{total_posts: 0, published_count: 0, draft_count: 0}}
+      end
+    end
+
+    # Generic action returning unconstrained map
+    action :get_metadata, :map do
+      run fn _input, _context ->
+        {:ok, %{}}
+      end
+    end
+
+    # Generic action returning primitive (not field selectable)
+    action :get_count, :integer do
+      run fn _input, _context ->
+        {:ok, 0}
+      end
+    end
+
+    # Generic action with no input
+    action :ping, :boolean do
+      run fn _input, _context ->
+        {:ok, true}
+      end
+    end
+
+    # Generic action with required input
+    action :search, {:array, :struct} do
+      constraints items: [instance_of: AshIntrospection.Test.Post]
+      argument :query, :string, allow_nil?: false, public?: true
+      argument :limit, :integer, default: 10, public?: true
+
+      run fn _input, _context ->
+        {:ok, []}
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `ActionIntrospection` module for analyzing action characteristics including pagination support, input requirements (required/optional/none), and return type analysis for generic actions
- Add `ValidationErrorTypes` module for classifying validation error structures for code generation (primitive, resource, typed container, array errors)
- Add comprehensive README with architecture overview, module reference, RPC pipeline documentation, and a complete guide for integrating new languages
- Update main module documentation with detailed architecture diagram and module descriptions

## Test plan

- [x] Run `mix test` to verify all new tests pass
- [x] Review `ActionIntrospection` tests for coverage of pagination, input type, and return type analysis
- [x] Review `ValidationErrorTypes` tests for error classification scenarios
- [x] Verify README renders correctly on GitHub