### PR TITLE
chore: prepare for Hex.pm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2025-12-21
+
+### Added
+
+- Action introspection module (`AshIntrospection.Codegen.ActionIntrospection`)
+  - Pagination support detection (offset/keyset)
+  - Input type analysis (required/optional/none)
+  - Return type analysis for generic actions
+- Validation error types module (`AshIntrospection.Codegen.ValidationErrorTypes`)
+  - Error type classification for code generation
+  - Action input error classification
+- Comprehensive documentation in README
+
+### Changed
+
+- Enhanced type discovery with better cycle detection
+- Improved field selector validation
+
+## [0.1.0] - 2025-11-25
+
+### Added
+
+- Initial release
+- Core type system introspection (`AshIntrospection.TypeSystem.Introspection`)
+  - Type classification and NewType unwrapping
+  - Union type extraction
+  - Field name callback detection
+- Resource fields lookup (`AshIntrospection.TypeSystem.ResourceFields`)
+- RPC pipeline for action execution (`AshIntrospection.Rpc.Pipeline`)
+  - 4-stage execution: parse, execute, process, format
+- Request structure (`AshIntrospection.Rpc.Request`)
+- Value formatter for bidirectional type conversion
+- Result processor with extraction templates
+- Field processing modules
+  - Atomizer for field name conversion
+  - Field selector for recursive selection
+  - Validation for duplicate detection
+- Error handling modules
+  - Error protocol for exception extraction
+  - Error builder for message generation
+  - Central error processing pipeline
+- Type discovery for code generation (`AshIntrospection.Codegen.TypeDiscovery`)
+- Field formatter utilities (camelCase, PascalCase, snake_case)

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ash_introspection contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ SPDX-License-Identifier: MIT
 [![Hex version badge](https://img.shields.io/hexpm/v/ash_introspection.svg)](https://hex.pm/packages/ash_introspection)
 [![Hexdocs badge](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/ash_introspection)
 
+> **Alpha Software**: This library is under active development. APIs may change without notice between versions. Use in production at your own risk.
+
 **Shared core library for Ash interoperability with multiple languages**
 
 AshIntrospection provides the foundational modules used by language-specific generators like [AshTypescript](https://github.com/ash-project/ash_typescript) and AshKotlinMultiplatform. It enables seamless RPC communication between Elixir/Ash backends and clients in TypeScript, Kotlin, Swift, and other languages.
@@ -702,7 +704,7 @@ Contributions are welcome! Please:
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License.
 
 ## Support
 

--- a/lib/ash_introspection.ex
+++ b/lib/ash_introspection.ex
@@ -6,6 +6,11 @@ defmodule AshIntrospection do
   @moduledoc """
   Shared core library for Ash interoperability with multiple languages.
 
+  > #### Alpha Software {: .warning}
+  >
+  > This library is under active development. APIs may change without notice
+  > between versions. Use in production at your own risk.
+
   AshIntrospection provides the foundational modules used by language-specific
   generators like `AshTypescript` and `AshKotlinMultiplatform`. It enables
   seamless RPC communication between Elixir/Ash backends and clients in other

--- a/mix.exs
+++ b/mix.exs
@@ -21,15 +21,60 @@ defmodule AshIntrospection.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       deps: deps(),
+      docs: docs(),
+      name: "AshIntrospection",
       description: @description,
-      source_url: "https://github.com/ash-project/ash_interop",
-      homepage_url: "https://github.com/ash-project/ash_interop",
+      source_url: "https://github.com/ash-project/ash_introspection",
+      homepage_url: "https://hexdocs.pm/ash_introspection",
       consolidate_protocols: Mix.env() != :test
     ]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
+
+  defp docs do
+    [
+      main: "readme",
+      extras: [
+        {"README.md", title: "Home"},
+        {"CHANGELOG.md", title: "Changelog"}
+      ],
+      groups_for_modules: [
+        "Type System": [
+          AshIntrospection.TypeSystem.Introspection,
+          AshIntrospection.TypeSystem.ResourceFields
+        ],
+        "RPC Pipeline": [
+          AshIntrospection.Rpc.Pipeline,
+          AshIntrospection.Rpc.Request,
+          AshIntrospection.Rpc.ValueFormatter,
+          AshIntrospection.Rpc.ResultProcessor,
+          AshIntrospection.Rpc.FieldExtractor
+        ],
+        "Field Processing": [
+          AshIntrospection.Rpc.FieldProcessing.Atomizer,
+          AshIntrospection.Rpc.FieldProcessing.FieldSelector,
+          AshIntrospection.Rpc.FieldProcessing.Validation
+        ],
+        "Error Handling": [
+          AshIntrospection.Rpc.Error,
+          AshIntrospection.Rpc.ErrorBuilder,
+          AshIntrospection.Rpc.Errors,
+          AshIntrospection.Rpc.DefaultErrorHandler
+        ],
+        "Code Generation": [
+          AshIntrospection.Codegen.TypeDiscovery,
+          AshIntrospection.Codegen.ActionIntrospection,
+          AshIntrospection.Codegen.ValidationErrorTypes
+        ],
+        Utilities: [
+          AshIntrospection.FieldFormatter,
+          AshIntrospection.Helpers
+        ]
+      ]
+    ]
+  end
 
   def application do
     [
@@ -45,7 +90,7 @@ defmodule AshIntrospection.MixProject do
       licenses: ["MIT"],
       files: ~w(lib .formatter.exs mix.exs README* CHANGELOG* LICENSES),
       links: %{
-        "GitHub" => "https://github.com/ash-project/ash_interop",
+        "GitHub" => "https://github.com/ash-project/ash_introspection",
         "Discord" => "https://discord.gg/HTHRaaVPUc",
         "Website" => "https://ash-hq.org",
         "Forum" => "https://elixirforum.com/c/elixir-framework-forums/ash-framework-forum"


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` with version history for 0.1.0 and 0.2.0
- Add `LICENSES/MIT.txt` for REUSE compliance
- Add ex_doc configuration with module groupings for HexDocs
- Update repository URLs from `ash_interop` to `ash_introspection`
- Add alpha software warning to README and module documentation

## Test plan

- [x] All 124 tests pass
- [x] `mix docs` generates without warnings
- [x] `mix hex.build` succeeds with all expected files