### PR TITLE
fix: redact ForbiddenField and NotLoaded in normalize_primitive

### DIFF
--- a/lib/ash_introspection/rpc/result_processor.ex
+++ b/lib/ash_introspection/rpc/result_processor.ex
@@ -531,8 +531,10 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
   Handles DateTime, Date, Time, Decimal, CiString, atoms, keyword lists, nested maps,
   regular lists, and Ash.Union types. Recursively normalizes nested structures.
 
-  `%Ash.ForbiddenField{}` and `%Ash.NotLoaded{}` normalize to `nil`, matching
-  the templated path in `extract_value/5`.
+  `%Ash.ForbiddenField{}` and `%Ash.NotLoaded{}` normalize to `nil`. Inside a
+  struct, map or keyword list a not-loaded field is omitted rather than sent as
+  `nil`, so the client can tell "you may not see this" apart from "this was not
+  loaded" — the same distinction the templated path draws in `extract_value/5`.
   """
   def normalize_primitive(nil), do: nil
 
@@ -582,7 +584,7 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
         value
         |> Map.from_struct()
         |> Enum.reduce(%{}, fn {key, val}, acc ->
-          Map.put(acc, key, normalize_primitive(val))
+          put_normalized(acc, key, val)
         end)
 
       is_list(value) ->
@@ -591,8 +593,7 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
         # is distinctly different from an empty object.
         if value != [] and Keyword.keyword?(value) do
           Enum.reduce(value, %{}, fn {key, val}, acc ->
-            string_key = to_string(key)
-            Map.put(acc, string_key, normalize_primitive(val))
+            put_normalized(acc, to_string(key), val)
           end)
         else
           Enum.map(value, &normalize_primitive/1)
@@ -600,7 +601,7 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
 
       is_map(value) ->
         Enum.reduce(value, %{}, fn {key, val}, acc ->
-          Map.put(acc, key, normalize_primitive(val))
+          put_normalized(acc, key, val)
         end)
 
       true ->
@@ -623,12 +624,18 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
     |> Map.from_struct()
     |> Enum.reduce(%{}, fn {key, val}, acc ->
       if MapSet.member?(public_field_names, key) do
-        Map.put(acc, key, normalize_primitive(val))
+        put_normalized(acc, key, val)
       else
         acc
       end
     end)
   end
+
+  # A not-loaded field is absent from the payload rather than `nil`, so the
+  # client never reads "not loaded" as "no value". Mirrors `extract_value/5`,
+  # which returns `:skip` for the same struct on the templated path.
+  defp put_normalized(acc, _key, %Ash.NotLoaded{}), do: acc
+  defp put_normalized(acc, key, value), do: Map.put(acc, key, normalize_primitive(value))
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Helper Functions

--- a/lib/ash_introspection/rpc/result_processor.ex
+++ b/lib/ash_introspection/rpc/result_processor.ex
@@ -530,8 +530,19 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
 
   Handles DateTime, Date, Time, Decimal, CiString, atoms, keyword lists, nested maps,
   regular lists, and Ash.Union types. Recursively normalizes nested structures.
+
+  `%Ash.ForbiddenField{}` and `%Ash.NotLoaded{}` normalize to `nil`, matching
+  the templated path in `extract_value/5`.
   """
   def normalize_primitive(nil), do: nil
+
+  # Authorization-redacted and unloaded fields must never be serialized: the
+  # generic struct branch below would `Map.from_struct/1` them and emit
+  # `Ash.ForbiddenField.original_value` — the real value the actor was denied,
+  # hidden only from `Inspect`. Ported from ash_typescript aa7f9f1
+  # (CVE-2026-82730).
+  def normalize_primitive(%Ash.ForbiddenField{}), do: nil
+  def normalize_primitive(%Ash.NotLoaded{}), do: nil
 
   def normalize_primitive(value) do
     cond do

--- a/test/ash_introspection/rpc/result_processor_redaction_test.exs
+++ b/test/ash_introspection/rpc/result_processor_redaction_test.exs
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ResultProcessorRedactionTest do
+  @moduledoc """
+  Guards the untemplated result path against disclosing values the actor was
+  denied.
+
+  `%Ash.ForbiddenField{}` carries the real value in `original_value` and hides
+  it only from `Inspect`, so any code that walks the struct's fields will
+  serialize the secret. These tests assert on what the client would actually
+  receive.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Rpc.ResultProcessor
+
+  @secret "123-45-6789"
+
+  defmodule Envelope do
+    @moduledoc false
+    defstruct [:label, :payload]
+  end
+
+  describe "normalize_primitive/1 with a forbidden field" do
+    test "redacts a bare forbidden field to nil" do
+      assert nil == ResultProcessor.normalize_primitive(forbidden(:ssn))
+    end
+
+    test "redacts a forbidden field nested in a plain struct" do
+      result =
+        ResultProcessor.normalize_primitive(%Envelope{label: "user", payload: forbidden(:ssn)})
+
+      assert %{label: "user", payload: nil} == result
+    end
+
+    test "redacts a forbidden field nested in an Ash resource struct" do
+      user = struct(AshIntrospection.Test.User, %{name: "Ada", email: forbidden(:email)})
+
+      result = ResultProcessor.normalize_primitive(user)
+
+      assert %{name: "Ada", email: nil} = result
+      refute leaks_secret?(result)
+    end
+
+    test "redacts a forbidden field nested in a plain map" do
+      result = ResultProcessor.normalize_primitive(%{name: "Ada", ssn: forbidden(:ssn)})
+
+      assert %{name: "Ada", ssn: nil} == result
+    end
+
+    test "redacts a forbidden field nested in a list" do
+      assert [nil, "Ada"] == ResultProcessor.normalize_primitive([forbidden(:ssn), "Ada"])
+    end
+
+    test "redacts a forbidden field nested in a keyword list" do
+      result = ResultProcessor.normalize_primitive(name: "Ada", ssn: forbidden(:ssn))
+
+      assert %{"name" => "Ada", "ssn" => nil} == result
+    end
+  end
+
+  describe "normalize_primitive/1 with a not-loaded field" do
+    test "redacts a bare not-loaded field to nil" do
+      assert nil == ResultProcessor.normalize_primitive(not_loaded(:address))
+    end
+  end
+
+  describe "process/4 without an extraction template" do
+    test "does not leak the value behind a forbidden field" do
+      user = struct(AshIntrospection.Test.User, %{name: "Ada", email: forbidden(:email)})
+
+      result = ResultProcessor.process(user, [], AshIntrospection.Test.User, %{})
+
+      refute leaks_secret?(result)
+    end
+  end
+
+  describe "Pipeline.process_result/3 for an unconstrained map action" do
+    test "redacts a forbidden field in the returned map" do
+      {:ok, result} = Pipeline.process_result(%{"ssn" => forbidden(:ssn)}, map_action_request())
+
+      assert %{"ssn" => nil} == result
+    end
+
+    test "redacts a forbidden field nested below the returned map" do
+      raw = %{"user" => %Envelope{label: "Ada", payload: forbidden(:ssn)}}
+
+      {:ok, result} = Pipeline.process_result(raw, map_action_request())
+
+      assert %{"user" => %{label: "Ada", payload: nil}} == result
+    end
+  end
+
+  defp map_action_request do
+    Request.new(%{
+      action: %{type: :action, returns: Ash.Type.Map, constraints: []},
+      extraction_template: [],
+      show_metadata: []
+    })
+  end
+
+  defp forbidden(field) do
+    %Ash.ForbiddenField{field: field, type: :attribute, original_value: @secret}
+  end
+
+  defp not_loaded(field) do
+    %Ash.NotLoaded{field: field, type: :attribute}
+  end
+
+  defp leaks_secret?(value) when is_binary(value), do: String.contains?(value, @secret)
+  defp leaks_secret?(%_{} = value), do: value |> Map.from_struct() |> leaks_secret?()
+
+  defp leaks_secret?(value) when is_map(value) do
+    Enum.any?(value, fn {key, val} -> leaks_secret?(key) or leaks_secret?(val) end)
+  end
+
+  defp leaks_secret?(value) when is_list(value), do: Enum.any?(value, &leaks_secret?/1)
+  defp leaks_secret?(_value), do: false
+end

--- a/test/ash_introspection/rpc/result_processor_redaction_test.exs
+++ b/test/ash_introspection/rpc/result_processor_redaction_test.exs
@@ -67,6 +67,31 @@ defmodule AshIntrospection.Rpc.ResultProcessorRedactionTest do
     test "redacts a bare not-loaded field to nil" do
       assert nil == ResultProcessor.normalize_primitive(not_loaded(:address))
     end
+
+    test "omits a not-loaded field nested in a plain struct" do
+      result =
+        ResultProcessor.normalize_primitive(%Envelope{
+          label: "user",
+          payload: not_loaded(:payload)
+        })
+
+      assert %{label: "user"} == result
+    end
+
+    test "omits a not-loaded field nested in an Ash resource struct" do
+      user = struct(AshIntrospection.Test.User, %{name: "Ada", email: not_loaded(:email)})
+
+      result = ResultProcessor.normalize_primitive(user)
+
+      assert "Ada" == result.name
+      refute Map.has_key?(result, :email)
+    end
+
+    test "omits a not-loaded field nested in a plain map" do
+      result = ResultProcessor.normalize_primitive(%{name: "Ada", address: not_loaded(:address)})
+
+      assert %{name: "Ada"} == result
+    end
   end
 
   describe "process/4 without an extraction template" do
@@ -92,6 +117,13 @@ defmodule AshIntrospection.Rpc.ResultProcessorRedactionTest do
       {:ok, result} = Pipeline.process_result(raw, map_action_request())
 
       assert %{"user" => %{label: "Ada", payload: nil}} == result
+    end
+
+    test "omits a not-loaded field in the returned map" do
+      {:ok, result} =
+        Pipeline.process_result(%{"address" => not_loaded(:address)}, map_action_request())
+
+      assert %{} == result
     end
   end
 


### PR DESCRIPTION
Closes #9

## Summary

`%Ash.ForbiddenField{}` carries the value the actor was denied in
`original_value` and hides it only from `Inspect`. `normalize_primitive/1` had
no clause for it, so the generic `is_struct/1` branch ran `Map.from_struct/1`
and recursed over every field — including `original_value` — and shipped the
secret to the client.

This is an authorization bypass by disclosure: the policy denied the field,
Ash marked it denied, and the serializer handed it over anyway.

Ports ash_typescript `aa7f9f1` (CVE-2026-82730).

## Why it was reachable

The templated path already redacts (`extract_value/5` at
`result_processor.ex:176-177`, `extract_resource_field/5` at `:293-296`,
`extract_resource_nested_field/6` at `:309-312`). The leak was the untemplated
fallback, reached from:

- `pipeline.ex:121-122` — an unconstrained map action sends the whole result
  through `normalize_primitive/1`, bypassing the template.
- `pipeline.ex:149` — the primitive-value branch.
- `result_processor.ex:569-574` — recursion, for a forbidden field nested
  inside another struct.

Live for `ash_kotlin_multiplatform` via `SharedPipeline.process_result/3`.

## What changed

Two commits, both in `lib/ash_introspection/rpc/result_processor.ex`:

1. **`fix: stop leaking the value behind a forbidden field`** — two clauses
   above the general one: `%Ash.ForbiddenField{}` and `%Ash.NotLoaded{}`
   normalize to `nil`. This is the security fix.
2. **`fix: omit not-loaded fields from untemplated results`** — a
   `put_normalized/3` helper drops a `%Ash.NotLoaded{}` field from the
   enclosing struct, map or keyword list rather than emitting `nil`. `nil`
   would tell the client the record has no value when the field was only never
   loaded; the templated path already omits the key, so the two paths now agree.

No change to `pipeline.ex`. The error path is untouched — it does not reach
this function (`normalize_value_for_json/1` has zero callers, and
`errors.ex` / `error.ex` / `error_builder.ex` never reference
`ResultProcessor`).

## Test plan

New file `test/ash_introspection/rpc/result_processor_redaction_test.exs` — the
first tests over `lib/ash_introspection/rpc/`. 14 tests, all asserting on the
value the client would receive, never on internals. A recursive `leaks_secret?/1`
walks the output for the plaintext, because `inspect/1` cannot be trusted here
(`ForbiddenField` hides the value from `Inspect`).

Coverage:

- `normalize_primitive/1` with a forbidden field: bare, nested in a plain
  struct, nested in an Ash resource struct, nested in a plain map, in a list,
  in a keyword list.
- `normalize_primitive/1` with a not-loaded field: bare, and omitted from a
  plain struct, an Ash resource struct and a plain map.
- `ResultProcessor.process/4` with an empty extraction template.
- `Pipeline.process_result/3` for an unconstrained map action — the real entry
  at `pipeline.ex:121-122`, exercised with a `%Request{}` whose action is
  `%{type: :action, returns: Ash.Type.Map, constraints: []}`.

Commands and results:

```
$ mix test test/ash_introspection/rpc/result_processor_redaction_test.exs
14 tests, 14 failures      # before the fix; output contained
                           # original_value: "123-45-6789"

$ mix test
138 tests, 0 failures      # after both commits
```

Verified the 4 not-loaded omission tests still fail against commit 1 alone
(`14 tests, 4 failures`), so commit 2 carries its own evidence.

## Note for the reviewer

`mix format` reformats 13 files on `main` that this PR does not touch — the
branch point is not formatter-clean under Elixir 1.18.4. I reverted that churn
and kept the diff to the fix. Worth a separate formatting-only PR. I confirmed
the formatter leaves every line this PR adds unchanged.
