### PR TITLE
fix: reject non-scalar identity and get_by values before the trusted filter

### DIFF
--- a/lib/ash_introspection/rpc/error_builder.ex
+++ b/lib/ash_introspection/rpc/error_builder.ex
@@ -432,6 +432,20 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
           }
         }
 
+      {:invalid_get_by, %{message: message}} ->
+        %{
+          type: "invalid_get_by",
+          message: message,
+          short_message: "Invalid getBy value",
+          vars: %{},
+          path: [:get_by],
+          fields: [],
+          details: %{
+            suggestion: "Provide a scalar value for each getBy field",
+            hint: @stale_generated_file_hint
+          }
+        }
+
       {:empty_fields_array, _fields} ->
         %{
           type: "empty_fields_array",

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -183,20 +183,20 @@ defmodule AshIntrospection.Rpc.Pipeline do
 
   defp execute_read_action(%Request{} = request, opts, config) do
     if Map.get(request.action, :get?, false) do
-      query =
-        request.resource
-        |> Ash.Query.for_read(request.action.name, request.input, opts)
-        |> apply_select_and_load(request)
-        |> apply_get_by_filter(request.get_by)
+      with {:ok, query} <-
+             request.resource
+             |> Ash.Query.for_read(request.action.name, request.input, opts)
+             |> apply_select_and_load(request)
+             |> apply_get_by_filter(request.get_by, config) do
+        not_found_error? = Map.get(config, :not_found_error?, true)
 
-      not_found_error? = Map.get(config, :not_found_error?, true)
+        case Ash.read_one(query) do
+          {:ok, nil} when not_found_error? ->
+            {:error, Ash.Error.Query.NotFound.exception(resource: request.resource)}
 
-      case Ash.read_one(query) do
-        {:ok, nil} when not_found_error? ->
-          {:error, Ash.Error.Query.NotFound.exception(resource: request.resource)}
-
-        result ->
-          result
+          result ->
+            result
+        end
       end
     else
       query =
@@ -361,11 +361,47 @@ defmodule AshIntrospection.Rpc.Pipeline do
   defp apply_filter(query, nil), do: query
   defp apply_filter(query, filter), do: Ash.Query.filter_input(query, filter)
 
-  defp apply_get_by_filter(query, nil), do: query
+  defp apply_get_by_filter(query, nil, _config), do: {:ok, query}
 
-  defp apply_get_by_filter(query, get_by) when is_map(get_by) do
-    filter = Enum.map(get_by, fn {field, value} -> {field, value} end)
-    Ash.Query.do_filter(query, filter)
+  defp apply_get_by_filter(query, get_by, config) when is_map(get_by) do
+    with :ok <- validate_scalar_get_by(get_by, config) do
+      filter = Enum.map(get_by, fn {field, value} -> {field, value} end)
+      {:ok, Ash.Query.do_filter(query, filter)}
+    end
+  end
+
+  # `get_by` values come from the client and are applied through the *trusted*
+  # filter API (Ash.Query.do_filter/2), which reads a map or list operand as an
+  # operator expression — `%{"less_than" => "b"}` becomes `field < "b"` — so an
+  # exact-record lookup silently widens into an arbitrary predicate. `get_by`
+  # lookups are equality-only, so reject any non-scalar value before it reaches
+  # the filter.
+  defp validate_scalar_get_by(get_by, config) do
+    case non_scalar_filter_keys(get_by) do
+      [] ->
+        :ok
+
+      keys ->
+        {:error,
+         {:invalid_get_by,
+          %{
+            message:
+              "getBy values must be scalar equality operands. Non-scalar value provided for: " <>
+                format_filter_keys(keys, config)
+          }}}
+    end
+  end
+
+  # JSON input yields only string, number, boolean, nil, list and map, so
+  # "neither map nor list" rejects every operator expression while preserving
+  # every legitimate operand — `false` and `nil` included.
+  defp non_scalar_filter_keys(values) do
+    for {key, value} <- values, is_map(value) or is_list(value), do: key
+  end
+
+  defp format_filter_keys(keys, config) do
+    formatter = Map.get(config, :output_field_formatter, :camel_case)
+    Enum.map_join(keys, ", ", &FieldFormatter.format_field_name(&1, formatter))
   end
 
   defp apply_sort(query, nil), do: query

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -80,10 +80,10 @@ defmodule AshIntrospection.Rpc.Pipeline do
           execute_create_action(request, opts)
 
         :update ->
-          execute_update_action(request, opts)
+          execute_update_action(request, opts, config)
 
         :destroy ->
-          execute_destroy_action(request, opts)
+          execute_destroy_action(request, opts, config)
 
         :action ->
           execute_generic_action(request, opts)
@@ -219,7 +219,7 @@ defmodule AshIntrospection.Rpc.Pipeline do
     |> Ash.create()
   end
 
-  defp execute_update_action(%Request{} = request, opts) do
+  defp execute_update_action(%Request{} = request, opts, config) do
     read_action = Map.get(request.rpc_action, :read_action)
     identities = Map.get(request.rpc_action, :identities, [:_primary_key])
 
@@ -229,7 +229,13 @@ defmodule AshIntrospection.Rpc.Pipeline do
       |> Ash.Query.set_context(opts[:context] || %{})
 
     with {:ok, query_with_identity} <-
-           maybe_apply_identity_filter(base_query, request.identity, identities, request.resource) do
+           maybe_apply_identity_filter(
+             base_query,
+             request.identity,
+             identities,
+             request.resource,
+             config
+           ) do
       query = Ash.Query.limit(query_with_identity, 1)
 
       bulk_opts = [
@@ -274,7 +280,7 @@ defmodule AshIntrospection.Rpc.Pipeline do
     end
   end
 
-  defp execute_destroy_action(%Request{} = request, opts) do
+  defp execute_destroy_action(%Request{} = request, opts, config) do
     read_action = Map.get(request.rpc_action, :read_action)
     identities = Map.get(request.rpc_action, :identities, [:_primary_key])
 
@@ -284,7 +290,13 @@ defmodule AshIntrospection.Rpc.Pipeline do
       |> Ash.Query.set_context(opts[:context] || %{})
 
     with {:ok, query_with_identity} <-
-           maybe_apply_identity_filter(base_query, request.identity, identities, request.resource) do
+           maybe_apply_identity_filter(
+             base_query,
+             request.identity,
+             identities,
+             request.resource,
+             config
+           ) do
       query =
         query_with_identity
         |> Ash.Query.limit(1)
@@ -429,31 +441,26 @@ defmodule AshIntrospection.Rpc.Pipeline do
   # Identity Helpers
   # ---------------------------------------------------------------------------
 
-  defp maybe_apply_identity_filter(query, _identity, [], _resource), do: {:ok, query}
+  defp maybe_apply_identity_filter(query, _identity, [], _resource, _config), do: {:ok, query}
 
-  defp maybe_apply_identity_filter(query, identity, identities, resource)
+  defp maybe_apply_identity_filter(query, identity, identities, resource, config)
        when is_map(identity) do
-    case build_identity_filter(resource, identity, identities) do
-      {:ok, filter} ->
-        {:ok, Ash.Query.do_filter(query, filter)}
-
-      {:error, _} = error ->
-        error
+    with {:ok, filter} <- build_identity_filter(resource, identity, identities),
+         :ok <- validate_scalar_identity_filter(filter, config) do
+      {:ok, Ash.Query.do_filter(query, filter)}
     end
   end
 
-  defp maybe_apply_identity_filter(query, identity, identities, resource)
+  defp maybe_apply_identity_filter(query, identity, identities, resource, config)
        when not is_nil(identity) do
-    case build_identity_filter(resource, identity, identities) do
-      {:ok, filter} ->
-        {:ok, Ash.Query.do_filter(query, filter)}
-
-      {:error, _} = error ->
-        error
+    with {:ok, filter} <- build_identity_filter(resource, identity, identities),
+         :ok <- validate_scalar_identity_filter(filter, config) do
+      {:ok, Ash.Query.do_filter(query, filter)}
     end
   end
 
-  defp maybe_apply_identity_filter(_query, nil, identities, resource) when identities != [] do
+  defp maybe_apply_identity_filter(_query, nil, identities, resource, _config)
+       when identities != [] do
     expected_keys = get_expected_identity_keys(resource, identities)
 
     {:error,
@@ -464,7 +471,32 @@ defmodule AshIntrospection.Rpc.Pipeline do
       }}}
   end
 
-  defp maybe_apply_identity_filter(query, _identity, _identities, _resource), do: {:ok, query}
+  defp maybe_apply_identity_filter(query, _identity, _identities, _resource, _config),
+    do: {:ok, query}
+
+  # Identity values come from the client and are applied through the *trusted*
+  # filter API (Ash.Query.do_filter/2), which reads a map or list operand as an
+  # operator expression — `%{"greater_than" => ""}` becomes `field > ""` — so
+  # an exact-record lookup silently widens into an arbitrary predicate. That
+  # predicate then drives `execute_update_action/3` and
+  # `execute_destroy_action/3`, so it mutates or deletes a record the caller
+  # never named. Identity lookups are equality-only, so reject any non-scalar
+  # value before it reaches the filter.
+  defp validate_scalar_identity_filter(filter, config) do
+    case non_scalar_filter_keys(filter) do
+      [] ->
+        :ok
+
+      keys ->
+        {:error,
+         {:invalid_identity,
+          %{
+            message:
+              "Identity values must be scalar equality operands. Non-scalar value provided for: " <>
+                format_filter_keys(keys, config)
+          }}}
+    end
+  end
 
   defp build_identity_filter(resource, identity, identities) when is_map(identity) do
     result =

--- a/test/ash_introspection/rpc/error_builder_test.exs
+++ b/test/ash_introspection/rpc/error_builder_test.exs
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ErrorBuilderTest do
+  @moduledoc """
+  The pipeline rejects non-scalar identity and `get_by` values with
+  `{:invalid_identity, _}` and `{:invalid_get_by, _}`. Both must reach the
+  client as their own error type — without a clause they fall through to the
+  generic `field_validation_error` fallback, which drops the message.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.ErrorBuilder
+
+  describe "invalid_get_by" do
+    test "keeps its own type, message and path" do
+      error =
+        ErrorBuilder.build_error_response(
+          {:invalid_get_by,
+           %{
+             message:
+               "getBy values must be scalar equality operands. Non-scalar value provided for: email"
+           }}
+        )
+
+      assert error.type == "invalid_get_by"
+      assert error.message =~ "scalar equality operands"
+      assert error.message =~ "email"
+      assert error.path == [:get_by]
+    end
+  end
+
+  describe "invalid_identity" do
+    test "keeps its own type and message when built from a bare message" do
+      error =
+        ErrorBuilder.build_error_response(
+          {:invalid_identity,
+           %{
+             message:
+               "Identity values must be scalar equality operands. Non-scalar value provided for: email"
+           }}
+        )
+
+      assert error.type == "invalid_identity"
+      assert error.message =~ "scalar equality operands"
+      assert error.path == [:identity]
+    end
+  end
+end

--- a/test/ash_introspection/rpc/pipeline_filter_injection_test.exs
+++ b/test/ash_introspection/rpc/pipeline_filter_injection_test.exs
@@ -4,7 +4,7 @@
 
 defmodule AshIntrospection.Rpc.PipelineFilterInjectionTest do
   @moduledoc """
-  `get_by` values arrive from the client and are applied through
+  Identity and `get_by` values arrive from the client and are applied through
   `Ash.Query.do_filter/2`, the *trusted* filter API. A map or list operand is
   read there as an operator expression rather than an equality match, so an
   exact-record lookup becomes an arbitrary predicate. These tests pin the
@@ -50,6 +50,36 @@ defmodule AshIntrospection.Rpc.PipelineFilterInjectionTest do
     })
   end
 
+  defp update_request(identity, identities, input) do
+    Request.new(%{
+      domain: RpcDomain,
+      resource: Account,
+      action: Ash.Resource.Info.action(Account, :update),
+      rpc_action: %{identities: identities},
+      input: input,
+      context: %{},
+      select: [:id, :name, :email],
+      load: [],
+      extraction_template: [:id, :name, :email],
+      identity: identity
+    })
+  end
+
+  defp destroy_request(identity, identities) do
+    Request.new(%{
+      domain: RpcDomain,
+      resource: Account,
+      action: Ash.Resource.Info.action(Account, :destroy),
+      rpc_action: %{identities: identities},
+      input: %{},
+      context: %{},
+      select: [:id, :name, :email],
+      load: [],
+      extraction_template: [:id, :name, :email],
+      identity: identity
+    })
+  end
+
   describe "get_by lookups" do
     test "an exact scalar value still resolves the named record", %{alice: alice} do
       assert {:ok, record} = Pipeline.execute_ash_action(get_request(%{email: alice.email}))
@@ -78,6 +108,70 @@ defmodule AshIntrospection.Rpc.PipelineFilterInjectionTest do
 
       assert message =~ "email"
       assert message =~ "name"
+    end
+  end
+
+  describe "identity lookups on update" do
+    test "an exact scalar identity still updates the named record", %{alice: alice, bob: bob} do
+      assert {:ok, record} =
+               Pipeline.execute_ash_action(
+                 update_request(%{email: alice.email}, [:unique_email], %{name: "Alice Renamed"})
+               )
+
+      assert record.id == alice.id
+      assert Ash.get!(Account, bob.id).name == "Bob"
+    end
+
+    test "rejects an operator map as a named identity value and leaves records untouched", %{
+      alice: alice,
+      bob: bob
+    } do
+      # Without validation this compiles to `email > ""` and the bulk update
+      # renames whichever account the data layer reads first.
+      assert {:error, {:invalid_identity, %{message: message}}} =
+               Pipeline.execute_ash_action(
+                 update_request(%{email: %{"greater_than" => ""}}, [:unique_email], %{
+                   name: "Injected"
+                 })
+               )
+
+      assert message =~ "email"
+      assert Ash.get!(Account, alice.id).name == "Alice"
+      assert Ash.get!(Account, bob.id).name == "Bob"
+    end
+
+    test "rejects a non-scalar primary key identity value", %{alice: alice} do
+      assert {:error, {:invalid_identity, _}} =
+               Pipeline.execute_ash_action(
+                 update_request([alice.id], [:_primary_key], %{name: "Injected PK"})
+               )
+
+      assert Ash.get!(Account, alice.id).name == "Alice"
+    end
+  end
+
+  describe "identity lookups on destroy" do
+    test "rejects an operator map as a named identity value and destroys nothing", %{
+      alice: alice,
+      bob: bob
+    } do
+      assert {:error, {:invalid_identity, _}} =
+               Pipeline.execute_ash_action(
+                 destroy_request(%{email: %{"greater_than" => ""}}, [:unique_email])
+               )
+
+      assert Ash.get!(Account, alice.id)
+      assert Ash.get!(Account, bob.id)
+    end
+
+    test "an exact scalar identity still destroys the named record", %{alice: alice, bob: bob} do
+      assert {:ok, _} =
+               Pipeline.execute_ash_action(
+                 destroy_request(%{email: alice.email}, [:unique_email])
+               )
+
+      assert {:error, _} = Ash.get(Account, alice.id)
+      assert Ash.get!(Account, bob.id)
     end
   end
 end

--- a/test/ash_introspection/rpc/pipeline_filter_injection_test.exs
+++ b/test/ash_introspection/rpc/pipeline_filter_injection_test.exs
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineFilterInjectionTest do
+  @moduledoc """
+  `get_by` values arrive from the client and are applied through
+  `Ash.Query.do_filter/2`, the *trusted* filter API. A map or list operand is
+  read there as an operator expression rather than an equality match, so an
+  exact-record lookup becomes an arbitrary predicate. These tests pin the
+  rejection and prove the legitimate scalar lookups still work.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.Account
+  alias AshIntrospection.Test.RpcDomain
+
+  setup do
+    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
+
+    suffix = System.unique_integer([:positive])
+
+    alice =
+      Account
+      |> Ash.Changeset.for_create(:create, %{name: "Alice", email: "alice-#{suffix}@example.com"})
+      |> Ash.create!()
+
+    bob =
+      Account
+      |> Ash.Changeset.for_create(:create, %{name: "Bob", email: "bob-#{suffix}@example.com"})
+      |> Ash.create!()
+
+    %{alice: alice, bob: bob}
+  end
+
+  defp get_request(get_by) do
+    Request.new(%{
+      domain: RpcDomain,
+      resource: Account,
+      action: Ash.Resource.Info.action(Account, :get_account),
+      rpc_action: %{},
+      input: %{},
+      context: %{},
+      select: [:id, :name, :email],
+      load: [],
+      extraction_template: [:id, :name, :email],
+      get_by: get_by
+    })
+  end
+
+  describe "get_by lookups" do
+    test "an exact scalar value still resolves the named record", %{alice: alice} do
+      assert {:ok, record} = Pipeline.execute_ash_action(get_request(%{email: alice.email}))
+      assert record.id == alice.id
+    end
+
+    test "rejects an operator map instead of matching a record the caller never named" do
+      # Without validation this compiles to `email < "zzz"` and returns whichever
+      # account the data layer reads first.
+      assert {:error, {:invalid_get_by, %{message: message}}} =
+               Pipeline.execute_ash_action(get_request(%{email: %{"less_than" => "zzz"}}))
+
+      assert message =~ "email"
+    end
+
+    test "rejects a list value", %{alice: alice, bob: bob} do
+      assert {:error, {:invalid_get_by, _}} =
+               Pipeline.execute_ash_action(get_request(%{email: [alice.email, bob.email]}))
+    end
+
+    test "names every non-scalar field in the error message" do
+      assert {:error, {:invalid_get_by, %{message: message}}} =
+               Pipeline.execute_ash_action(
+                 get_request(%{email: %{"less_than" => "zzz"}, name: ["Alice"]})
+               )
+
+      assert message =~ "email"
+      assert message =~ "name"
+    end
+  end
+end

--- a/test/support/rpc_resources.ex
+++ b/test/support/rpc_resources.ex
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.RpcDomain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource(AshIntrospection.Test.Account)
+  end
+end
+
+defmodule AshIntrospection.Test.Account do
+  @moduledoc """
+  Resource for exercising the RPC pipeline's identity and `get_by` lookups.
+
+  Carries a named identity (`:unique_email`) plus a `get?` read action so the
+  pipeline's two trusted-filter paths — `maybe_apply_identity_filter/5` and
+  `apply_get_by_filter/3` — can both be driven end to end.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.RpcDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:name, :string, allow_nil?: false, public?: true)
+    attribute(:email, :string, allow_nil?: false, public?: true)
+  end
+
+  identities do
+    identity(:unique_email, [:email], pre_check_with: AshIntrospection.Test.RpcDomain)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+
+    read :get_account do
+      get?(true)
+    end
+  end
+end


### PR DESCRIPTION
Closes #8

## Summary

Client-supplied identity and `get_by` values reached `Ash.Query.do_filter/2`
— the **trusted** filter API — with no scalar check. A map operand is read
there as an operator expression, not an equality match, so an exact-record
lookup silently became an arbitrary predicate. This PR rejects any map or list
value at both filter sites before it reaches the filter.

## Why it matters

The vulnerability was reproduced against `AshIntrospection.Rpc.Pipeline` before
the fix. Two observed failures on `main`:

* `get_by: %{email: %{"less_than" => "zzz"}}` compiled to
  `#Ash.Filter<email < "zzz">` and matched two records.
* `identity: %{email: %{"greater_than" => ""}}` on an update compiled to
  `email > ""`, and `Ash.bulk_update/4` renamed a record the caller never
  named — `%Account{name: "Injected", email: "bob-124745@example.com"}` when
  the caller only ever addressed Alice.

The same widening drives the destroy path, so an attacker could delete a
predicate-matched record instead of the one they named. Reachable today through
`execute_read_action/3`, `execute_update_action/3` and
`execute_destroy_action/3` — every consumer that calls
`execute_ash_action/2`, including `ash_kotlin_multiplatform`, which validates
neither.

## What changed

| Change | File |
| --- | --- |
| `validate_scalar_get_by/2` rejects non-scalar `get_by` values; `apply_get_by_filter/3` now returns `{:ok, query}` / `{:error, _}` | `lib/ash_introspection/rpc/pipeline.ex` |
| `validate_scalar_identity_filter/2` rejects non-scalar identity values on both `maybe_apply_identity_filter/5` clauses (named identity and primary key) | `lib/ash_introspection/rpc/pipeline.ex` |
| Pipeline config threaded through `execute_update_action/3` and `execute_destroy_action/3` so rejected field names use the caller's output formatter | `lib/ash_introspection/rpc/pipeline.ex` |
| `{:invalid_get_by, _}` clause, mirroring the existing `{:invalid_identity, _}` clause, with `path: [:get_by]` | `lib/ash_introspection/rpc/error_builder.ex` |
| First tests over `lib/ash_introspection/rpc/` — 11 new tests | `test/ash_introspection/rpc/` |
| Test-only `AshIntrospection.Test.Account` with a named identity and a `get?` read action | `test/support/rpc_resources.ex` |

The check is `not (is_map(value) or is_list(value))`. JSON input yields only
string, number, boolean, nil, list and map, so it rejects every operator
expression while preserving every legitimate operand — `false` and `nil`
included.

Ports upstream `ash_typescript` `27186c3` and `2b4f423`. Upstream validates at
parse time; this library has no parse stage, so the check sits at the filter
sites instead.

No public API changed: `execute_ash_action/2` keeps its arity and its
`{:ok, term()} | {:error, term()}` contract.

## Test plan

```
mix test
135 tests, 0 failures
```

```
mix compile --force --warnings-as-errors
Compiling 20 files (.ex)
Generated ash_introspection app
```

Each fix was written test-first. Before the implementation, the six injection
tests failed with the attacker-controlled outcomes quoted above; the three
legitimate-scalar tests passed throughout, so the rejection does not narrow
what a real caller can do.

New coverage in `test/ash_introspection/rpc/pipeline_filter_injection_test.exs`
(9 tests):

* `get_by` — scalar value still resolves the named record; operator map
  rejected; list rejected; every non-scalar field named in the message.
* identity on update — scalar identity still updates the named record and
  leaves its neighbour alone; operator map rejected with both records verified
  untouched afterwards; non-scalar primary key rejected.
* identity on destroy — operator map rejected with both records still present;
  scalar identity still destroys exactly the named record.

`test/ash_introspection/rpc/error_builder_test.exs` (2 tests) pins that
`invalid_get_by` and `invalid_identity` each keep their own `type`, `message`
and `path` rather than falling through to the generic
`field_validation_error` fallback.

## Notes for the reviewer

* `mix format` was run only on the files this PR touches. A blanket
  `mix format` rewrites 13 unrelated files because `.formatter.exs` is missing
  `import_deps: [:ash, :spark]`; that is a separate ticket, kept out of this
  diff.
* A struct identity value (a `DateTime` in a composite identity, say) is a map
  and is now rejected. Client input arrives as JSON, so values reach this code
  as strings and no current caller is affected — but a future caller that
  pre-casts identity values would be. Upstream has the same behaviour.
