### PR TITLE
fix: stop minting atoms from client-supplied field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,40 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+
+- Client-supplied field names no longer mint atoms
+  ([#10](https://github.com/udin-io/ash_introspection/issues/10)). The atom
+  table is never garbage collected, so a request carrying unknown field names
+  grew it without bound and could take the node down. Field selection now
+  resolves names against atoms that already exist and rejects the rest as
+  unknown fields.
+
+### Added
+
+- `AshIntrospection.FieldFormatter.resolve_field_name/2` — resolves a field
+  name to an existing atom, or returns the formatted string when none exists.
+- `AshIntrospection.Rpc.FieldProcessing.Validation.field_exists?/2` — field
+  existence check that accepts a string name, which `Keyword.has_key?/2`
+  rejects.
+
+### Fixed
+
+- String field names on a resource with no interop name mapping resolved to
+  `nil`, so valid names were rejected and unknown ones reported as
+  `{:unknown_field, nil, resource, path}`.
+
+### Removed
+
+- **Breaking:** `AshIntrospection.FieldFormatter.convert_to_field_atom/2`. Its
+  contract was to always produce an atom, which is the vulnerability itself.
+  Callers passing client input should use `resolve_field_name/2`; callers that
+  genuinely hold a trusted name already have the atom.
 
 ## [0.2.0] - 2025-12-21
 
@@ -13,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pagination support detection (offset/keyset)
   - Input type analysis (required/optional/none)
   - Return type analysis for generic actions
-- Validation error types module (`AshIntrospection.Codegen.ValidationErrorTypes`)
+- Validation error types module
+  (`AshIntrospection.Codegen.ValidationErrorTypes`)
   - Error type classification for code generation
   - Action input error classification
 - Comprehensive documentation in README

--- a/lib/ash_introspection/field_formatter.ex
+++ b/lib/ash_introspection/field_formatter.ex
@@ -186,10 +186,47 @@ defmodule AshIntrospection.FieldFormatter do
   end
 
   @doc """
+  Resolves a field name to the atom that already names that field.
+
+  Atoms pass through unchanged. A string is parsed into internal form by the
+  formatter and resolved against the existing atom table; when no such atom
+  exists the parsed string is returned unchanged.
+
+  Every field a resource or type declares gets its atom at compile time, so a
+  valid name always resolves. An unresolved name is one no field has, and
+  callers compare the result against the declared field atoms — a string never
+  matches one, so it fails as an unknown field.
+
+  This deliberately never calls `String.to_atom/1`. Field names come from
+  clients and the atom table is never garbage collected, so minting one atom per
+  name lets an unauthenticated caller exhaust it and take the node down.
+
+  ## Examples
+
+      iex> AshIntrospection.FieldFormatter.resolve_field_name("userName", :camel_case)
+      :user_name
+
+      iex> AshIntrospection.FieldFormatter.resolve_field_name(:user_name, :snake_case)
+      :user_name
+  """
+  def resolve_field_name(field_name, _formatter) when is_atom(field_name) do
+    field_name
+  end
+
+  def resolve_field_name(field_name, formatter) when is_binary(field_name) do
+    parse_input_field(field_name, formatter)
+  end
+
+  @doc """
   Converts a field name to an atom, using the formatter to parse the name first.
 
   This is useful when you need to ensure the field name is an atom for
   use as a map key or keyword list key.
+
+  > #### Unsafe on client input {: .warning}
+  >
+  > This mints a permanent atom for any name that does not already have one.
+  > Use `resolve_field_name/2` for anything a client can influence.
 
   ## Examples
 

--- a/lib/ash_introspection/field_formatter.ex
+++ b/lib/ash_introspection/field_formatter.ex
@@ -217,38 +217,6 @@ defmodule AshIntrospection.FieldFormatter do
     parse_input_field(field_name, formatter)
   end
 
-  @doc """
-  Converts a field name to an atom, using the formatter to parse the name first.
-
-  This is useful when you need to ensure the field name is an atom for
-  use as a map key or keyword list key.
-
-  > #### Unsafe on client input {: .warning}
-  >
-  > This mints a permanent atom for any name that does not already have one.
-  > Use `resolve_field_name/2` for anything a client can influence.
-
-  ## Examples
-
-      iex> AshIntrospection.FieldFormatter.convert_to_field_atom("userName", :camel_case)
-      :user_name
-
-      iex> AshIntrospection.FieldFormatter.convert_to_field_atom(:user_name, :snake_case)
-      :user_name
-  """
-  def convert_to_field_atom(field_name, _formatter) when is_atom(field_name) do
-    field_name
-  end
-
-  def convert_to_field_atom(field_name, formatter) when is_binary(field_name) do
-    parsed = parse_input_field(field_name, formatter)
-
-    case parsed do
-      atom when is_atom(atom) -> atom
-      string when is_binary(string) -> String.to_atom(string)
-    end
-  end
-
   # Private helper for parsing field names from client format to internal format
   defp parse_field_name(field_name, formatter) do
     case formatter do

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -557,18 +557,18 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       Enum.reduce(requested_fields, {[], [], []}, fn field, {select, load, template} ->
         case parse_field_request(field) do
           {:simple, field_name} ->
-            internal_name = convert_to_field_atom(field_name, config)
+            internal_name = resolve_field_name(field_name, config)
 
-            unless Keyword.has_key?(field_specs, internal_name) do
+            unless Validation.field_exists?(field_specs, internal_name) do
               throw({:unknown_field, field_name, error_type, path})
             end
 
             {select, load, template ++ [internal_name]}
 
           {:nested, field_name, nested_fields} ->
-            internal_name = convert_to_field_atom(field_name, config)
+            internal_name = resolve_field_name(field_name, config)
 
-            unless Keyword.has_key?(field_specs, internal_name) do
+            unless Validation.field_exists?(field_specs, internal_name) do
               throw({:unknown_field, field_name, error_type, path})
             end
 
@@ -587,7 +587,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
 
           {:multi_nested, entries} ->
             Enum.reduce(entries, {select, load, template}, fn {field_name, nested}, {s, l, t} ->
-              internal_name = convert_to_field_atom(field_name, config)
+              internal_name = resolve_field_name(field_name, config)
               Validation.validate_field_exists!(internal_name, field_specs, path, error_type)
 
               field_spec = Keyword.get(field_specs, internal_name)
@@ -629,9 +629,9 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       Enum.reduce(requested_fields, {[], [], []}, fn field, {select, load, template} ->
         case parse_field_request(field) do
           {:simple, field_name} ->
-            field_atom = convert_to_field_atom(field_name, config)
+            field_atom = resolve_field_name(field_name, config)
 
-            if Keyword.has_key?(field_specs, field_atom) do
+            if Validation.field_exists?(field_specs, field_atom) do
               index = Enum.find_index(field_names, &(&1 == field_atom))
               {select, load, template ++ [%{field_name: field_atom, index: index}]}
             else
@@ -639,9 +639,9 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
             end
 
           {:nested, field_name, nested_fields} ->
-            field_atom = convert_to_field_atom(field_name, config)
+            field_atom = resolve_field_name(field_name, config)
 
-            if Keyword.has_key?(field_specs, field_atom) do
+            if Validation.field_exists?(field_specs, field_atom) do
               field_spec = Keyword.get(field_specs, field_atom)
               field_type = Keyword.get(field_spec, :type)
               field_constraints = Keyword.get(field_spec, :constraints, [])
@@ -657,9 +657,9 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
 
           {:multi_nested, entries} ->
             Enum.reduce(entries, {select, load, template}, fn {field_name, nested_fields}, {s, l, t} ->
-              field_atom = convert_to_field_atom(field_name, config)
+              field_atom = resolve_field_name(field_name, config)
 
-              unless Keyword.has_key?(field_specs, field_atom) do
+              unless Validation.field_exists?(field_specs, field_atom) do
                 throw({:unknown_field, field_atom, "tuple", path})
               end
 
@@ -935,10 +935,10 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     if is_interop_resource?(resource, config) do
       case get_original_field_name(resource, field_name, config) do
         original when is_atom(original) -> original
-        _ -> convert_to_field_atom(field_name, config)
+        _ -> resolve_field_name(field_name, config)
       end
     else
-      convert_to_field_atom(field_name, config)
+      resolve_field_name(field_name, config)
     end
   end
 
@@ -946,9 +946,12 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     get_original_field_name(resource, field_name, config)
   end
 
-  defp convert_to_field_atom(field_name, config) do
+  # Resolves a client field name to the atom that names an existing field, or
+  # leaves it a string when no such atom exists. Never mints: an unresolved name
+  # is one no field has, and every existence check below rejects a string.
+  defp resolve_field_name(field_name, config) do
     formatter = Map.get(config, :input_field_formatter, :camel_case)
-    FieldFormatter.convert_to_field_atom(field_name, formatter)
+    FieldFormatter.resolve_field_name(field_name, formatter)
   end
 
   defp requires_nested_selection?(type, type_constraints, config) do

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -522,13 +522,12 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
 
   defp resolve_typed_struct_field(field_name, reverse_map, config) when is_binary(field_name) do
     case Map.get(reverse_map, field_name) do
-      nil ->
-        formatter = Map.get(config, :input_field_formatter, :camel_case)
-        converted = FieldFormatter.parse_input_field(field_name, formatter)
-        if is_atom(converted), do: converted, else: String.to_atom(converted)
-
-      internal ->
-        internal
+      # A name absent from the interop map names no field of this struct, so it
+      # stays a string and fails Validation.validate_field_exists!/4 as an
+      # unknown field. Minting an atom here only let client input grow the atom
+      # table.
+      nil -> resolve_field_name(field_name, config)
+      internal -> internal
     end
   end
 

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -878,7 +878,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   defp atomize_field_name(field, resource, config) when is_binary(field) do
     if is_interop_resource?(resource, config) do
       case get_original_field_name(resource, field, config) do
-        original when is_atom(original) -> original
+        original when is_atom(original) and not is_nil(original) -> original
         _ -> field
       end
     else
@@ -934,7 +934,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   defp resolve_resource_field_name(resource, field_name, config) when is_binary(field_name) do
     if is_interop_resource?(resource, config) do
       case get_original_field_name(resource, field_name, config) do
-        original when is_atom(original) -> original
+        original when is_atom(original) and not is_nil(original) -> original
         _ -> resolve_field_name(field_name, config)
       end
     else

--- a/lib/ash_introspection/rpc/field_processing/validation.ex
+++ b/lib/ash_introspection/rpc/field_processing/validation.ex
@@ -115,19 +115,34 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Validation do
   - `path` - Current path for error reporting
   - `error_type` - Error type string for error messages
   """
-  @spec validate_field_exists!(atom(), keyword(), list(), String.t()) :: :ok
+  @spec validate_field_exists!(atom() | String.t(), keyword(), list(), String.t()) :: :ok
   def validate_field_exists!(
         field_name,
         field_specs,
         path,
         error_type \\ "field_constrained_type"
       ) do
-    unless Keyword.has_key?(field_specs, field_name) do
+    unless field_exists?(field_specs, field_name) do
       throw({:unknown_field, field_name, error_type, path})
     end
 
     :ok
   end
+
+  @doc """
+  Checks whether `field_specs` declares `field_name`.
+
+  Accepts a string name, which `Keyword.has_key?/2` rejects outright. A client
+  name that resolved to no existing atom stays a string, and no field spec can
+  be keyed by one, so the answer is always false — the caller then reports it as
+  an unknown field.
+  """
+  @spec field_exists?(keyword(), term()) :: boolean()
+  def field_exists?(field_specs, field_name) when is_atom(field_name) do
+    Keyword.has_key?(field_specs, field_name)
+  end
+
+  def field_exists?(_field_specs, _field_name), do: false
 
   # Normalizes a string field name using the formatter, resolving it to an
   # existing atom where one exists. Never mints an atom: this runs on raw client

--- a/lib/ash_introspection/rpc/field_processing/validation.ex
+++ b/lib/ash_introspection/rpc/field_processing/validation.ex
@@ -24,6 +24,11 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Validation do
   Normalizes field names using the input formatter before checking for duplicates.
   Throws `{:duplicate_field, field_name, path}` if duplicates are found.
 
+  This runs before any field-existence check, so it sees every name a client
+  sent, valid or not. A name that matches no existing atom stays a string here
+  and is reported as such; the caller rejects it as an unknown field moments
+  later.
+
   ## Parameters
 
   - `fields` - List of field selections
@@ -124,8 +129,10 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Validation do
     :ok
   end
 
-  # Normalizes a string field name to an atom using the formatter
+  # Normalizes a string field name using the formatter, resolving it to an
+  # existing atom where one exists. Never mints an atom: this runs on raw client
+  # input before anything has checked the name against a real field.
   defp normalize_field_name(field_name, formatter) when is_binary(field_name) do
-    FieldFormatter.convert_to_field_atom(field_name, formatter)
+    FieldFormatter.resolve_field_name(field_name, formatter)
   end
 end

--- a/test/ash_introspection/field_formatter_atom_safety_test.exs
+++ b/test/ash_introspection/field_formatter_atom_safety_test.exs
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.FieldFormatterAtomSafetyTest do
+  @moduledoc """
+  Regression coverage for issue #10: a client-supplied field name must never
+  mint a new atom. The atom table is never garbage collected, so one request per
+  unique name is an unauthenticated denial of service against the whole node.
+
+  Per-name assertions probe `String.to_existing_atom/1` rather than sampling the
+  global atom count, which concurrent test modules would perturb.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.FieldFormatter
+
+  defp atom_exists?(name) when is_binary(name) do
+    _ = String.to_existing_atom(name)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
+  describe "resolve_field_name/2" do
+    test "resolves a camelCase name to the existing atom" do
+      # The atom exists because this module names it.
+      _ = :user_name
+      assert FieldFormatter.resolve_field_name("userName", :camel_case) == :user_name
+    end
+
+    test "passes atoms through unchanged" do
+      assert FieldFormatter.resolve_field_name(:already_atom, :camel_case) == :already_atom
+    end
+
+    test "returns the formatted string for an unknown name without minting an atom" do
+      name = "atomBombFieldName#{System.unique_integer([:positive])}Xyz"
+
+      result = FieldFormatter.resolve_field_name(name, :camel_case)
+
+      assert is_binary(result)
+      refute atom_exists?(result)
+    end
+
+    test "mints no atoms for a batch of unique unknown names" do
+      names = for i <- 1..1000, do: "atomBombBatch#{i}Zz#{System.unique_integer([:positive])}"
+
+      Enum.each(names, fn name ->
+        result = FieldFormatter.resolve_field_name(name, :camel_case)
+        assert is_binary(result)
+        refute atom_exists?(result)
+      end)
+    end
+
+    test "handles names longer than the 255-character atom limit" do
+      long = String.duplicate("a", 300)
+
+      assert FieldFormatter.resolve_field_name(long, :camel_case) == long
+    end
+  end
+end

--- a/test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs
+++ b/test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelectorAtomSafetyTest do
+  @moduledoc """
+  Regression coverage for issue #10 through the public entry point,
+  `FieldSelector.process/4`.
+
+  Every field name in a request reaches this module before anything has checked
+  it against a real field. Minting an atom per name let an unauthenticated
+  caller fill the atom table, which is never garbage collected, and take the
+  node down. Each selection path gets its own case because each resolves names
+  differently.
+
+  The batch cases assert on `:erlang.system_info(:atom_count)`, so this module is
+  synchronous — a concurrent module compiling or resolving atoms would move that
+  number.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
+  alias AshIntrospection.Test.Post
+
+  @batch_size 500
+
+  defp atom_exists?(name) when is_binary(name) do
+    _ = String.to_existing_atom(name)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
+  defp unknown_name(prefix), do: "#{prefix}#{System.unique_integer([:positive])}Zz"
+
+  # A name is only safe if neither the wire form nor the internal snake_case form
+  # gained an atom - the old code minted the latter.
+  defp refute_atoms_for(name) do
+    refute atom_exists?(name)
+    refute atom_exists?(Macro.underscore(name))
+  end
+
+  # Runs `fun` once to settle any first-call atom creation in Ash or the error
+  # path, then asserts the next `@batch_size` distinct names add no atoms.
+  defp assert_no_atoms_minted(fun) do
+    fun.(unknown_name("atomBombWarmup"))
+
+    before = :erlang.system_info(:atom_count)
+
+    for _ <- 1..@batch_size do
+      fun.(unknown_name("atomBombBatch"))
+    end
+
+    assert :erlang.system_info(:atom_count) == before
+  end
+
+  describe "typed map fields" do
+    test "an unknown field name is rejected without minting an atom" do
+      name = unknown_name("atomBombTypedMap")
+
+      assert {:error, {:unknown_field, unknown, "map", []}} =
+               FieldSelector.process(Post, :get_stats, [name])
+
+      assert is_binary(unknown)
+      refute_atoms_for(name)
+    end
+
+    test "a batch of unknown field names mints no atoms" do
+      assert_no_atoms_minted(fn name ->
+        assert {:error, {:unknown_field, _, _, _}} =
+                 FieldSelector.process(Post, :get_stats, [name])
+      end)
+    end
+
+    test "an unknown nested field name is rejected without minting an atom" do
+      name = unknown_name("atomBombNestedTypedMap")
+
+      assert {:error, {:unknown_field, unknown, "map", []}} =
+               FieldSelector.process(Post, :get_stats, [%{name => ["id"]}])
+
+      assert is_binary(unknown)
+      refute_atoms_for(name)
+    end
+
+    test "known field names still resolve" do
+      assert {:ok, {_select, _load, template}} =
+               FieldSelector.process(Post, :get_stats, ["totalPosts", "draftCount"])
+
+      assert template == [:total_posts, :draft_count]
+    end
+  end
+
+  describe "tuple fields" do
+    test "an unknown field name is rejected without minting an atom" do
+      name = unknown_name("atomBombTuple")
+
+      assert {:error, {:unknown_field, unknown, "tuple", []}} =
+               FieldSelector.process(Post, :get_bounds, [name])
+
+      assert is_binary(unknown)
+      refute_atoms_for(name)
+    end
+
+    test "a batch of unknown field names mints no atoms" do
+      assert_no_atoms_minted(fn name ->
+        assert {:error, {:unknown_field, _, _, _}} =
+                 FieldSelector.process(Post, :get_bounds, [name])
+      end)
+    end
+
+    test "known field names still resolve" do
+      assert {:ok, {_select, _load, template}} =
+               FieldSelector.process(Post, :get_bounds, ["latitude", "longitude"])
+
+      assert template == [
+               %{field_name: :latitude, index: 0},
+               %{field_name: :longitude, index: 1}
+             ]
+    end
+  end
+end

--- a/test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs
+++ b/test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs
@@ -144,6 +144,32 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelectorAtomSafetyTest do
     end
   end
 
+  describe "typed struct fields" do
+    test "an unknown field name is rejected without minting an atom" do
+      name = unknown_name("atomBombTypedStruct")
+
+      assert {:error, {:unknown_field, unknown, "field_constrained_type", []}} =
+               FieldSelector.process(Post, :get_task_stats, [name])
+
+      assert is_binary(unknown)
+      refute_atoms_for(name)
+    end
+
+    test "a batch of unknown field names mints no atoms" do
+      assert_no_atoms_minted(fn name ->
+        assert {:error, {:unknown_field, _, _, _}} =
+                 FieldSelector.process(Post, :get_task_stats, [name])
+      end)
+    end
+
+    test "mapped field names still resolve to their internal atoms" do
+      assert {:ok, {_select, _load, template}} =
+               FieldSelector.process(Post, :get_task_stats, ["isActive", "taskCount", "meta1"])
+
+      assert template == [:is_active?, :task_count, :meta_1]
+    end
+  end
+
   describe "tuple fields" do
     test "an unknown field name is rejected without minting an atom" do
       name = unknown_name("atomBombTuple")

--- a/test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs
+++ b/test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs
@@ -21,6 +21,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelectorAtomSafetyTest do
 
   alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
   alias AshIntrospection.Test.Post
+  alias AshIntrospection.Test.User
 
   @batch_size 500
 
@@ -40,18 +41,71 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelectorAtomSafetyTest do
     refute atom_exists?(Macro.underscore(name))
   end
 
-  # Runs `fun` once to settle any first-call atom creation in Ash or the error
-  # path, then asserts the next `@batch_size` distinct names add no atoms.
+  # Runs a full warm-up batch first: Ash's own lazy initialisation creates a few
+  # hundred atoms the first time a selection path runs, and only then does the
+  # count settle. Every batch after that must add exactly zero, which is what
+  # separates a fixed path from one minting an atom per name.
   defp assert_no_atoms_minted(fun) do
-    fun.(unknown_name("atomBombWarmup"))
+    run_batch(fun, "atomBombWarmup")
 
     before = :erlang.system_info(:atom_count)
-
-    for _ <- 1..@batch_size do
-      fun.(unknown_name("atomBombBatch"))
-    end
+    names = run_batch(fun, "atomBombBatch")
 
     assert :erlang.system_info(:atom_count) == before
+    Enum.each(names, &refute_atoms_for/1)
+  end
+
+  defp run_batch(fun, prefix) do
+    for _ <- 1..@batch_size do
+      name = unknown_name(prefix)
+      fun.(name)
+      name
+    end
+  end
+
+  describe "resource fields" do
+    test "an unknown field name is rejected without minting an atom" do
+      name = unknown_name("atomBombResource")
+
+      assert {:error, {:unknown_field, unknown, User, []}} =
+               FieldSelector.process(User, :read, [name])
+
+      assert is_binary(unknown)
+      refute_atoms_for(name)
+    end
+
+    test "a batch of unknown field names mints no atoms" do
+      assert_no_atoms_minted(fn name ->
+        assert {:error, {:unknown_field, _, _, _}} = FieldSelector.process(User, :read, [name])
+      end)
+    end
+
+    test "an unknown nested field name is rejected without minting an atom" do
+      name = unknown_name("atomBombNestedResource")
+
+      assert {:error, {:unknown_field, unknown, User, []}} =
+               FieldSelector.process(User, :read, [%{name => ["id"]}])
+
+      assert is_binary(unknown)
+      refute_atoms_for(name)
+    end
+
+    test "known attribute and aggregate names still resolve" do
+      assert {:ok, {select, load, template}} =
+               FieldSelector.process(User, :read, ["id", "name", "isActive", "addressCount"])
+
+      assert select == [:id, :name, :is_active]
+      assert load == [:address_count]
+      assert template == [:id, :name, :is_active, :address_count]
+    end
+
+    test "known relationship names still resolve" do
+      assert {:ok, {_select, load, template}} =
+               FieldSelector.process(User, :read, [%{"address" => ["street", "city"]}])
+
+      assert load == [{:address, [:street, :city]}]
+      assert template == [address: [:street, :city]]
+    end
   end
 
   describe "typed map fields" do

--- a/test/ash_introspection/rpc/field_processing/validation_atom_safety_test.exs
+++ b/test/ash_introspection/rpc/field_processing/validation_atom_safety_test.exs
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.FieldProcessing.ValidationAtomSafetyTest do
+  @moduledoc """
+  Regression coverage for issue #10 at the duplicate-name check.
+
+  `check_for_duplicates/3` runs before any field-existence check, so it saw
+  every client-supplied name including garbage. Normalising those names through
+  the old `convert_to_field_atom/2` minted an atom per name on every request.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.FieldProcessing.Validation
+
+  defp atom_exists?(name) when is_binary(name) do
+    _ = String.to_existing_atom(name)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
+  defp unknown_name(prefix), do: "#{prefix}#{System.unique_integer([:positive])}Zz"
+
+  describe "check_for_duplicates/3" do
+    test "accepts unknown field names without minting atoms" do
+      names = for _ <- 1..200, do: unknown_name("atomBombDup")
+
+      assert :ok = Validation.check_for_duplicates(names, [], %{})
+
+      Enum.each(names, fn name ->
+        refute atom_exists?(Macro.underscore(name))
+      end)
+    end
+
+    test "accepts unknown keys in nested field maps without minting atoms" do
+      names = for _ <- 1..200, do: unknown_name("atomBombNested")
+      fields = Enum.map(names, fn name -> %{name => ["id"]} end)
+
+      assert :ok = Validation.check_for_duplicates(fields, [], %{})
+
+      Enum.each(names, fn name ->
+        refute atom_exists?(Macro.underscore(name))
+      end)
+    end
+
+    test "still reports a repeated unknown name as a duplicate" do
+      name = unknown_name("atomBombRepeat")
+
+      assert catch_throw(Validation.check_for_duplicates([name, name], [:foo], %{})) ==
+               {:duplicate_field, Macro.underscore(name), [:foo]}
+    end
+
+    test "still reports a known name repeated across formats as a duplicate" do
+      assert catch_throw(
+               Validation.check_for_duplicates(["userName", :user_name], [], %{
+                 input_field_formatter: :camel_case
+               })
+             ) == {:duplicate_field, :user_name, []}
+    end
+  end
+end

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -237,6 +237,18 @@ defmodule AshIntrospection.Test.Post do
       end
     end
 
+    # Generic action returning a tuple with named fields
+    action :get_bounds, :tuple do
+      constraints fields: [
+                    latitude: [type: :float],
+                    longitude: [type: :float]
+                  ]
+
+      run fn _input, _context ->
+        {:ok, {0.0, 0.0}}
+      end
+    end
+
     # Generic action returning unconstrained map
     action :get_metadata, :map do
       run fn _input, _context ->

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -237,6 +237,13 @@ defmodule AshIntrospection.Test.Post do
       end
     end
 
+    # Generic action returning a NewType that maps field names for interop
+    action :get_task_stats, AshIntrospection.Test.TaskStats do
+      run fn _input, _context ->
+        {:ok, %{is_active?: true, task_count: 0, meta_1: "none"}}
+      end
+    end
+
     # Generic action returning a tuple with named fields
     action :get_bounds, :tuple do
       constraints fields: [


### PR DESCRIPTION
Closes #10

Ports upstream `ash_typescript` `df95df4` (CVE-2026-74837) and `0ab5c83`
(CVE-2026-77856).

## The DoS

Field selection turned every client-supplied field name into an atom. The BEAM
atom table is never garbage collected and is capped (1,048,576 by default), so
an unauthenticated caller sending one request per unique junk name walks the
node into `system_limit` and kills it. No login, no rate limit, no recovery
short of a restart.

Measured on `origin/main`, 20,000 unique unknown names per selection path:

| path | atoms minted |
|---|---|
| resource (`User`, `:read`) | 20,000 |
| typed map (`Post`, `:get_stats`) | 20,000 |
| typed struct (`Post`, `:get_task_stats`) | 20,000 |
| tuple (`Post`, `:get_bounds`) | 20,000 |

Exactly one atom per name, on every path. Same measurement on this branch:
0 across all four, at 50,000 names each.

## The fix

`FieldFormatter.resolve_field_name/2` replaces `convert_to_field_atom/2`. It
resolves a name against atoms that **already exist** and returns the formatted
string when none does. Every field a resource or type declares gets its atom at
compile time, so a valid name always resolves; an unresolved name is one no
field has, and the existence checks reject it as an unknown field.

```mermaid
flowchart LR
  C["client field name"] --> P["FieldSelector.process/4"]
  P --> D["Validation.check_for_duplicates/3"]
  D --> R["FieldFormatter.resolve_field_name/2"]
  R -->|"atom exists"| A[":field_atom"]
  R -->|"no atom"| S["\"fieldName\" (string)"]
  A --> E["existence check"]
  S --> E
  E -->|"declared"| OK["select / load / template"]
  E -->|"not declared"| ERR["{:unknown_field, name, type, path}"]
```

Three minting sites are gone:

- `field_formatter.ex` — `convert_to_field_atom/2` ended in `String.to_atom/1`.
- `validation.ex` — `check_for_duplicates/3` normalised names **before** any
  existence check, so junk alone minted an atom on every request. This is the
  path that made the resource selector vulnerable.
- `field_selector.ex` — `resolve_typed_struct_field/3` fell back to
  `String.to_atom/1` for names the interop map did not cover.

Letting a name stay a string broke the existence checks, which used
`Keyword.has_key?/2` — it guards on `is_atom(key)` and raises
`FunctionClauseError` on a string. New `Validation.field_exists?/2` accepts a
string and answers `false`, so an unknown name gets a clean
`{:unknown_field, ...}` error rather than a crash. It is a plain `false` because
no field spec can be keyed by a string.

### Bug found while porting

`get_original_field_name/3` returns `nil` when a resource has no interop name
mapping, and `nil` is an atom, so the `original when is_atom(original)` clause
matched it. Every string field name on a plain Ash resource therefore resolved
to `nil`: valid names were rejected, and unknown ones came back as
`{:unknown_field, nil, resource, path}` naming nothing. Upstream carries the
`and not is_nil(original)` guard; this branch adds it. Without it
`resolve_field_name/2` is unreachable on the resource path, so the port would
have been dead code there.

### Why `convert_to_field_atom/2` was removed rather than kept

Its documented contract — *always* return an atom — is the vulnerability. There
is no safe way to call it with client input, and no caller inside the library
wants it: a caller holding a trusted name already has the atom. Leaving it on
the public API invites a consumer to reintroduce the bug, and
`ash_kotlin_multiplatform` is about to migrate onto exactly this module. Removed
outright, as upstream did, and recorded as a breaking change in the changelog
(pre-1.0, 0.2.0).

## Unblocks ash_kotlin_multiplatform#19

That issue's fix is to drop its hand-rolled field selection and call
`AshIntrospection.Rpc.FieldSelector.process/4` instead. It could not do that
while `FieldSelector` still minted atoms — it would have swapped its own copy
of the bug (`runner.ex:370`) for this one. With this merged, the migration is
safe.

## Test plan

New coverage, all through public functions — `FieldSelector.process/4`,
`FieldFormatter.resolve_field_name/2`, `Validation.check_for_duplicates/3`:

- `test/ash_introspection/field_formatter_atom_safety_test.exs` — resolution,
  passthrough, a 1,000-name batch, and names over the 255-char atom limit.
- `test/ash_introspection/rpc/field_processing/validation_atom_safety_test.exs`
  — the pre-existence-check path, plus proof duplicate detection still works
  for unresolved names.
- `test/ash_introspection/rpc/field_processing/field_selector_atom_safety_test.exs`
  — all four selection paths: unknown name rejected cleanly with no atom, a
  500-name batch with `:erlang.system_info(:atom_count)` flat, and known names
  still resolving.

Two test-support actions were added to `AshIntrospection.Test.Post` to reach the
previously untested paths: `:get_task_stats` (typed struct) and `:get_bounds`
(tuple).

The batch cases run a full warm-up batch first: Ash's lazy initialisation
creates a few hundred atoms the first time a selection path runs and then
settles at zero, so a single warm-up call is not enough and the assertion would
flake by a couple of atoms.

Commands run in the worktree:

```
mix test                          # 148 tests, 0 failures (was 124 on main)
mix test --seed 0 / 7 / 42 / 1234 / 99999   # 148 tests, 0 failures each
mix compile --force               # no new warnings
```

The atom-count assertion is the flaky-looking one, so it was run across five
seeds; it holds. `mix format` was run on `field_formatter.ex`, `validation.ex`
and the new test files, which were already formatter-clean.
`field_selector.ex` and `test/support/resources.ex` are two of the 13 files
`main` leaves unformatted (#30), so they were edited by hand and verified: the
formatter rewrites nothing this PR touched in them.
