### PR TITLE
fix: stop leaking policy breakdowns and exception messages in RPC errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to
   development toggle opened every RPC response. The message is now the static
   `"forbidden"` and the `policy_breakdown` key is gone.
 
+- Unknown errors no longer return the raw exception text
+  ([#11](https://github.com/udin-io/ash_introspection/issues/11)).
+  `Ash.Error.Unknown.UnknownError` is the bucket every unrecognised exception
+  falls into, so its message could be a connection string, a stack trace or a
+  third-party library's internals. Clients now get `"Something went wrong"`.
+
 - Client-supplied field names no longer mint atoms
   ([#10](https://github.com/udin-io/ash_introspection/issues/10)). The atom
   table is never garbage collected, so a request carrying unknown field names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to
 
 ### Security
 
+- Forbidden errors no longer render the policy breakdown to the client
+  ([#11](https://github.com/udin-io/ash_introspection/issues/11)).
+  `Exception.message/1` on `Ash.Error.Forbidden.Policy` returns the whole
+  authorization report — every policy, every check outcome, and the actor
+  inspected in full — whenever Ash's app-wide
+  `config :ash, :policies, show_policy_breakdowns?: true` is set, so a
+  development toggle opened every RPC response. The message is now the static
+  `"forbidden"` and the `policy_breakdown` key is gone.
+
 - Client-supplied field names no longer mint atoms
   ([#10](https://github.com/udin-io/ash_introspection/issues/10)). The atom
   table is never garbage collected, so a request carrying unknown field names
@@ -19,6 +28,10 @@ and this project adheres to
 
 ### Added
 
+- `config :ash_introspection, :policies, show_policy_breakdowns?: true` — opt
+  in to sending the policy breakdown back as the forbidden error's message.
+  Deliberately a separate setting from Ash's own `:ash, :policies`, so an
+  app-wide development toggle cannot open RPC responses in production.
 - `AshIntrospection.FieldFormatter.resolve_field_name/2` — resolves a field
   name to an existing atom, or returns the formatted string when none exists.
 - `AshIntrospection.Rpc.FieldProcessing.Validation.field_exists?/2` — field

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ end
 | `AshIntrospection.Rpc.Errors` | Central error processing pipeline |
 | `AshIntrospection.Rpc.DefaultErrorHandler` | Pass-through error handler |
 
+Client-facing error messages are deliberately terse: a policy failure returns
+`"forbidden"` and an unrecognised exception returns `"Something went wrong"`,
+so neither the authorization rules nor the crash text reach the caller. To see
+the policy breakdown while debugging, opt in explicitly:
+
+```elixir
+config :ash_introspection, :policies, show_policy_breakdowns?: true
+```
+
+That setting is separate from Ash's own
+`config :ash, :policies, show_policy_breakdowns?: true` on purpose — an
+app-wide development toggle must not be able to open RPC responses. Never
+enable it in production.
+
 ### Code Generation
 
 | Module | Description |

--- a/lib/ash_introspection/rpc/error.ex
+++ b/lib/ash_introspection/rpc/error.ex
@@ -111,21 +111,42 @@ defimpl AshIntrospection.Rpc.Error, for: Ash.Error.Query.Required do
 end
 
 defimpl AshIntrospection.Rpc.Error, for: Ash.Error.Forbidden.Policy do
+  # `Exception.message/1` on this error renders the whole authorization report -
+  # every policy, every check outcome, and the actor inspected in full - as soon
+  # as the struct's `policy_breakdown?` flag is set, and Ash sets that flag from
+  # its app-wide `:ash, :policies, show_policy_breakdowns?` toggle when the
+  # exception is built. That toggle is a development aid, so reading it here
+  # would let a stray dev setting open every RPC response in production.
+  #
+  # The breakdown is gated on this library's own config instead, which nothing
+  # but an explicit decision turns on:
+  #
+  #     config :ash_introspection, :policies, show_policy_breakdowns?: true
+  #
+  # Mirrors ash_graphql's separate `show_policy_descriptions?` setting, and
+  # ports upstream ash_typescript ef29ceb.
   def to_error(error) do
-    base = %{
-      message: Exception.message(error),
+    message =
+      if show_policy_breakdowns?() do
+        Ash.Error.Forbidden.Policy.report(error, help_text?: false)
+      else
+        "forbidden"
+      end
+
+    %{
+      message: message,
       short_message: "Forbidden",
       vars: Map.new(error.vars || []),
       type: "forbidden",
       fields: [],
       path: error.path || []
     }
+  end
 
-    if Map.get(error, :policy_breakdown?) do
-      Map.put(base, :policy_breakdown, Map.get(error, :policies))
-    else
-      base
-    end
+  defp show_policy_breakdowns? do
+    :ash_introspection
+    |> Application.get_env(:policies, [])
+    |> Keyword.get(:show_policy_breakdowns?, false)
   end
 end
 

--- a/lib/ash_introspection/rpc/error.ex
+++ b/lib/ash_introspection/rpc/error.ex
@@ -255,9 +255,12 @@ defimpl AshIntrospection.Rpc.Error, for: Ash.Error.Query.ReadActionRequiresActor
 end
 
 defimpl AshIntrospection.Rpc.Error, for: Ash.Error.Unknown.UnknownError do
+  # This is the bucket every unrecognised exception falls into, so its text is
+  # whatever crashed - a database URL, a stack trace, a third-party library's
+  # internals. The client gets a static message; the detail belongs in the logs.
   def to_error(error) do
     %{
-      message: Exception.message(error),
+      message: "Something went wrong",
       short_message: "Unknown error",
       vars: Map.new(error.vars || []),
       type: "unknown_error",

--- a/test/ash_introspection/rpc/error_detail_leak_test.exs
+++ b/test/ash_introspection/rpc/error_detail_leak_test.exs
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ErrorDetailLeakTest do
+  @moduledoc """
+  Guards the client-facing error payload against disclosing server internals.
+
+  `Ash.Error.Forbidden.Policy.message/1` renders the entire authorization
+  report — every policy, every check outcome, and the actor inspected in full
+  — whenever the struct's `policy_breakdown?` flag is set, and Ash sets that
+  flag from its own app-wide `:ash, :policies` toggle at exception time.
+  The report reaches the client through the `AshIntrospection.Rpc.Error`
+  protocol, so these tests assert on the payload a client would receive and scan
+  it recursively for a sentinel rather than trusting a single key.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.Error, as: ErrorProtocol
+  alias AshIntrospection.Rpc.Errors
+
+  @actor_secret "sk-live-4f9c1a-ACTOR-SENTINEL"
+  @policy_secret "only the owning tenant may read POLICY-SENTINEL"
+
+  setup do
+    on_exit(fn ->
+      Application.delete_env(:ash_introspection, :policies)
+      Application.delete_env(:ash, :policies)
+    end)
+  end
+
+  describe "Ash.Error.Forbidden.Policy" do
+    test "message is static when no breakdown config is set" do
+      result = ErrorProtocol.to_error(policy_error())
+
+      assert result.message == "forbidden"
+      assert result.short_message == "Forbidden"
+      assert result.type == "forbidden"
+    end
+
+    test "never attaches a policy_breakdown key" do
+      Application.put_env(:ash, :policies, show_policy_breakdowns?: true)
+      Application.put_env(:ash_introspection, :policies, show_policy_breakdowns?: true)
+
+      refute Map.has_key?(ErrorProtocol.to_error(policy_error()), :policy_breakdown)
+    end
+
+    test "does not leak the report when Ash's own app-wide toggle is enabled" do
+      Application.put_env(:ash, :policies, show_policy_breakdowns?: true)
+
+      error = policy_error()
+
+      # Ash's message/1 is the leak this fix exists to close.
+      assert Exception.message(error) =~ @actor_secret
+      assert Exception.message(error) =~ @policy_secret
+
+      result = ErrorProtocol.to_error(error)
+
+      assert result.message == "forbidden"
+      refute leaks?(result)
+    end
+
+    test "does not leak the report through the full error pipeline" do
+      Application.put_env(:ash, :policies, show_policy_breakdowns?: true)
+
+      [result] = Errors.to_errors(policy_error())
+
+      assert result.message == "forbidden"
+      refute leaks?(result)
+    end
+
+    test "includes the report when ash_introspection is explicitly opted in" do
+      Application.put_env(:ash_introspection, :policies, show_policy_breakdowns?: true)
+
+      result = ErrorProtocol.to_error(policy_error())
+
+      assert result.message =~ "Policy Breakdown"
+      assert result.message =~ @policy_secret
+      assert result.short_message == "Forbidden"
+    end
+
+    test "opted-in breakdown does not depend on Ash's app-wide toggle" do
+      Application.put_env(:ash_introspection, :policies, show_policy_breakdowns?: true)
+      Application.put_env(:ash, :policies, show_policy_breakdowns?: false)
+
+      assert ErrorProtocol.to_error(policy_error()).message =~ "Policy Breakdown"
+    end
+
+    test "opted-in payload still encodes to JSON" do
+      Application.put_env(:ash_introspection, :policies, show_policy_breakdowns?: true)
+
+      [result] = Errors.to_errors(policy_error())
+
+      assert {:ok, _json} = Jason.encode(result)
+    end
+  end
+
+  defp policy_error do
+    Ash.Error.Forbidden.Policy.exception(
+      resource: AshIntrospection.Test.Account,
+      action: :read,
+      actor: %{id: "user_1", api_token: @actor_secret},
+      policies: [
+        %Ash.Policy.Policy{
+          description: @policy_secret,
+          condition: [],
+          policies: [],
+          bypass?: false,
+          access_type: :strict
+        }
+      ],
+      facts: %{},
+      must_pass_strict_check?: false
+    )
+  end
+
+  defp leaks?(value) when is_binary(value) do
+    Enum.any?([@actor_secret, @policy_secret], &String.contains?(value, &1))
+  end
+
+  defp leaks?(%_{} = value), do: value |> Map.from_struct() |> leaks?()
+
+  defp leaks?(value) when is_map(value) do
+    Enum.any?(value, fn {key, val} -> leaks?(key) or leaks?(val) end)
+  end
+
+  defp leaks?(value) when is_list(value), do: Enum.any?(value, &leaks?/1)
+  defp leaks?(value) when is_atom(value), do: leaks?(Atom.to_string(value))
+  defp leaks?(_value), do: false
+end

--- a/test/ash_introspection/rpc/error_detail_leak_test.exs
+++ b/test/ash_introspection/rpc/error_detail_leak_test.exs
@@ -10,9 +10,10 @@ defmodule AshIntrospection.Rpc.ErrorDetailLeakTest do
   report — every policy, every check outcome, and the actor inspected in full
   — whenever the struct's `policy_breakdown?` flag is set, and Ash sets that
   flag from its own app-wide `:ash, :policies` toggle at exception time.
-  The report reaches the client through the `AshIntrospection.Rpc.Error`
-  protocol, so these tests assert on the payload a client would receive and scan
-  it recursively for a sentinel rather than trusting a single key.
+  `Ash.Error.Unknown.UnknownError` carries the raw exception text. Both reach
+  the client through the `AshIntrospection.Rpc.Error` protocol, so these tests
+  assert on the payload a client would receive and scan it recursively for a
+  sentinel rather than trusting a single key.
   """
   use ExUnit.Case, async: false
 
@@ -21,6 +22,7 @@ defmodule AshIntrospection.Rpc.ErrorDetailLeakTest do
 
   @actor_secret "sk-live-4f9c1a-ACTOR-SENTINEL"
   @policy_secret "only the owning tenant may read POLICY-SENTINEL"
+  @exception_secret "postgres://appuser:hunter2@10.0.0.7/prod EXCEPTION-SENTINEL"
 
   setup do
     on_exit(fn ->
@@ -95,6 +97,29 @@ defmodule AshIntrospection.Rpc.ErrorDetailLeakTest do
     end
   end
 
+  describe "Ash.Error.Unknown.UnknownError" do
+    test "returns a static message instead of the exception text" do
+      error = Ash.Error.Unknown.UnknownError.exception(error: @exception_secret)
+
+      assert Exception.message(error) =~ @exception_secret
+
+      result = ErrorProtocol.to_error(error)
+
+      assert result.message == "Something went wrong"
+      assert result.short_message == "Unknown error"
+      assert result.type == "unknown_error"
+      refute leaks?(result)
+    end
+
+    test "does not leak the exception text through the full error pipeline" do
+      [result] =
+        Errors.to_errors(Ash.Error.Unknown.UnknownError.exception(error: @exception_secret))
+
+      assert result.message == "Something went wrong"
+      refute leaks?(result)
+    end
+  end
+
   defp policy_error do
     Ash.Error.Forbidden.Policy.exception(
       resource: AshIntrospection.Test.Account,
@@ -115,7 +140,7 @@ defmodule AshIntrospection.Rpc.ErrorDetailLeakTest do
   end
 
   defp leaks?(value) when is_binary(value) do
-    Enum.any?([@actor_secret, @policy_secret], &String.contains?(value, &1))
+    Enum.any?([@actor_secret, @policy_secret, @exception_secret], &String.contains?(value, &1))
   end
 
   defp leaks?(%_{} = value), do: value |> Map.from_struct() |> leaks?()


### PR DESCRIPTION
Two error protocol implementations in `lib/ash_introspection/rpc/error.ex`
handed server internals to the client through `Exception.message/1`. Both are
ports of the upstream ash_typescript fixes.

Closes #11

## What leaked

**`Ash.Error.Forbidden.Policy`** — `Exception.message/1` renders the entire
authorization report whenever the struct's `policy_breakdown?` flag is set, and
Ash sets that flag when the exception is built, from its app-wide
`config :ash, :policies, show_policy_breakdowns?`. Confirmed first-hand in
`deps/ash/lib/ash/error/forbidden/policy.ex:31-60` and `:242-262`. The report
carries the policy descriptions, every check outcome, the generated filter, and
`inspect(actor)` in full. A test built with an actor of
`%{id: "user_1", api_token: "sk-live-..."}` got this back as the client
message:

```
forbidden:

AshIntrospection.Test.Account.read

Policy Breakdown
  Actor: %{id: "user_1", api_token: "sk-live-4f9c1a-ACTOR-SENTINEL"}

  only the owning tenant may read POLICY-SENTINEL | ...
```

The impl additionally attached the raw `policies` list under a
`policy_breakdown` key.

**`Ash.Error.Unknown.UnknownError`** — the bucket every unrecognised exception
falls into, so its message is whatever crashed: a connection string with
credentials, a stack trace, a third-party library's internals.

## What changed

- Forbidden policy errors return the static message `"forbidden"`. The
  `policy_breakdown` key is gone.
- Unknown errors return `"Something went wrong"`. The detail stays in the logs.
- New opt-in config, default `false`:

  ```elixir
  config :ash_introspection, :policies, show_policy_breakdowns?: true
  ```

## Why it ignores Ash's own setting

Reading `:ash, :policies, show_policy_breakdowns?` here would defeat the fix.
That toggle is a development aid an operator turns on to debug an
authorization failure locally; if the RPC layer honoured it, leaving it on in a
shared or production config would silently open every RPC response. The gate is
therefore a separate `:ash_introspection` setting that nothing but an explicit
decision turns on. ash_graphql draws the same line with its own
`show_policy_descriptions?`. A test asserts the property directly: with
`:ash, :policies, show_policy_breakdowns?: true` set, the payload is still
`"forbidden"`.

## Ports

- `ef29ceb` — prevent policy breakdown leak in Forbidden.Policy responses
- `5024048` — don't expose exception messages for unknown errors

## Test plan

New file `test/ash_introspection/rpc/error_detail_leak_test.exs`, 9 tests. They
assert on the payload a client receives — via the protocol and via
`Errors.to_errors/1` — and scan it recursively for sentinel strings rather
than trusting a single key, following the technique from #29. Coverage:

- static message with no config set
- no `policy_breakdown` key, ever
- no leak when Ash's app-wide toggle is on (the test first asserts
  `Exception.message/1` *does* leak, so it fails if Ash stops leaking and the
  guard becomes vacuous)
- no leak through the full `Errors.to_errors/1` pipeline
- breakdown present when `:ash_introspection` is opted in
- opt-in works with Ash's toggle explicitly off
- opted-in payload still JSON-encodes
- unknown error returns the static message and does not leak the exception text,
  both directly and through the pipeline

Commands and results:

| Command | Result |
|---|---|
| `mix test` | 182 tests, 0 failures (was 173 on `main`) |
| `mix compile --force` | no warnings |
| `mix format --check-formatted lib/ash_introspection/rpc/error.ex test/ash_introspection/rpc/error_detail_leak_test.exs` | clean |

`mix format` was run on the two touched `.ex`/`.exs` files only — a blanket
run rewrites ~13 unrelated files because `.formatter.exs` is missing
`import_deps` (#30).

## Behaviour change for consumers

Clients that displayed the forbidden error message to end users now show
`"forbidden"` instead of a report, and unknown errors show
`"Something went wrong"`. Anything reading the `policy_breakdown` key must
switch to the opt-in config. Noted in the changelog.
