### PR TITLE
fix: fail closed when a configured error handler crashes

### DIFF
--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -246,15 +246,7 @@ defmodule AshIntrospection.Rpc.Errors do
     end
     """)
 
-    %{
-      message: "Something went wrong. Unique error id: #{uuid}",
-      short_message: "Internal error",
-      code: "internal_error",
-      vars: %{},
-      fields: [],
-      path: Map.get(error, :path, []),
-      error_id: uuid
-    }
+    generic_internal_error(uuid, Map.get(error, :path, []))
   end
 
   defp handle_unimplemented_error(error, _show_raised_errors?) do
@@ -266,15 +258,7 @@ defmodule AshIntrospection.Rpc.Errors do
     Error: #{inspect(error)}
     """)
 
-    %{
-      message: "Something went wrong. Unique error id: #{uuid}",
-      short_message: "Internal error",
-      code: "internal_error",
-      vars: %{},
-      fields: [],
-      path: [],
-      error_id: uuid
-    }
+    generic_internal_error(uuid, [])
   end
 
   defp fallback_error_response(error, _show_raised_errors?) when is_exception(error) do

--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -146,13 +146,38 @@ defmodule AshIntrospection.Rpc.Errors do
     end
   rescue
     e ->
-      Logger.warning("""
-      Error handler failed: #{inspect(e)}
-      Handler: #{inspect({module, function, args})}
-      Original error: #{inspect(error)}
-      """)
+      handler_failure(inspect(e), __STACKTRACE__, {module, function, args}, error)
+  end
 
-      error
+  # Error handlers are the application's hook for redacting or suppressing errors
+  # before they reach the client, so a handler that fails must fail closed - never
+  # fall back to the unredacted error it was supposed to sanitize. The generic
+  # error carries a UUID so the real error stays correlatable in the server log.
+  defp handler_failure(reason, stacktrace, handler, error) do
+    uuid = Ash.UUID.generate()
+
+    Logger.error("""
+    Error handler failed, returning a generic error instead of the unhandled one.
+    Error ID: #{uuid}
+    Handler: #{inspect(handler)}
+    Failure: #{reason}
+    Original error: #{inspect(error)}
+    #{Exception.format_stacktrace(stacktrace)}
+    """)
+
+    generic_internal_error(uuid, [])
+  end
+
+  defp generic_internal_error(uuid, path) do
+    %{
+      message: "Something went wrong. Unique error id: #{uuid}",
+      short_message: "Internal error",
+      code: "internal_error",
+      vars: %{},
+      fields: [],
+      path: path,
+      error_id: uuid
+    }
   end
 
   defp get_domain_error_handler(domain, config) do

--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -147,6 +147,14 @@ defmodule AshIntrospection.Rpc.Errors do
   rescue
     e ->
       handler_failure(inspect(e), __STACKTRACE__, {module, function, args}, error)
+  catch
+    kind, reason ->
+      handler_failure(
+        "#{kind}: #{inspect(reason)}",
+        __STACKTRACE__,
+        {module, function, args},
+        error
+      )
   end
 
   # Error handlers are the application's hook for redacting or suppressing errors

--- a/test/ash_introspection/rpc/errors_handler_failure_test.exs
+++ b/test/ash_introspection/rpc/errors_handler_failure_test.exs
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ErrorsHandlerFailureTest do
+  @moduledoc """
+  A configured error handler is the application's only hook for redacting an
+  error before it reaches the client. When that hook crashes, returning the
+  error it was supposed to sanitize hands the client exactly the disclosure the
+  handler existed to prevent — the one path in the pipeline that must fail
+  closed instead failing open.
+
+  Handlers are usually written as a function head matching the error shapes the
+  developer anticipated, so an unanticipated shape raises `FunctionClauseError`
+  rather than being passed through deliberately. These tests pin the closed
+  behaviour for a handler that raises.
+  """
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias AshIntrospection.Rpc.Errors
+
+  @secret "search backend unreachable at es.internal:9200 (token=S3cr3t-Pr0d-Pw)"
+
+  defmodule RaisingHandler do
+    @moduledoc false
+    def handle_rpc_error(%{type: "invalid_attribute"} = error, _context) do
+      %{error | message: "Invalid value.", short_message: "Invalid value", vars: %{}}
+    end
+
+    # No clause for any other error type -> FunctionClauseError.
+  end
+
+  describe "a handler that succeeds" do
+    test "redacts the error class it matches" do
+      [response] = to_errors(RaisingHandler, invalid_attribute())
+
+      assert response.message == "Invalid value."
+      refute leaks_secret?(response)
+    end
+  end
+
+  describe "a handler that crashes" do
+    test "returns a generic error when the handler raises" do
+      assert_fails_closed(RaisingHandler)
+    end
+  end
+
+  describe "the log left behind by a crashed handler" do
+    test "carries the error id the client was given" do
+      {[response], log} = with_log(fn -> to_errors(RaisingHandler, invalid_argument()) end)
+
+      assert log =~ response.error_id
+    end
+
+    test "carries the handler, the failure and the original error" do
+      {_response, log} = with_log(fn -> to_errors(RaisingHandler, invalid_argument()) end)
+
+      assert log =~ inspect(RaisingHandler)
+      assert log =~ "FunctionClauseError"
+      assert log =~ @secret
+    end
+  end
+
+  defp assert_fails_closed(handler) do
+    {[response], _log} = with_log(fn -> to_errors(handler, invalid_argument()) end)
+
+    assert response.code == "internal_error"
+    assert response.short_message == "Internal error"
+    assert response.vars == %{}
+    assert response.fields == []
+    assert is_binary(response.error_id)
+    assert response.message == "Something went wrong. Unique error id: #{response.error_id}"
+    refute leaks_secret?(response)
+  end
+
+  defp to_errors(handler, error) do
+    Errors.to_errors(error, nil, handler, nil, %{}, %{})
+  end
+
+  # An error class the handler has no clause for, carrying a sentinel that must
+  # never reach the client.
+  defp invalid_argument do
+    Ash.Error.Query.InvalidArgument.exception(field: :filter, message: @secret)
+  end
+
+  defp invalid_attribute do
+    Ash.Error.Changes.InvalidAttribute.exception(field: :email, message: @secret)
+  end
+
+  defp leaks_secret?(value) when is_binary(value), do: String.contains?(value, @secret)
+  defp leaks_secret?(value) when is_atom(value), do: leaks_secret?(Atom.to_string(value))
+  defp leaks_secret?(%_{} = value), do: value |> Map.from_struct() |> leaks_secret?()
+
+  defp leaks_secret?(value) when is_map(value) do
+    Enum.any?(value, fn {key, val} -> leaks_secret?(key) or leaks_secret?(val) end)
+  end
+
+  defp leaks_secret?(value) when is_list(value), do: Enum.any?(value, &leaks_secret?/1)
+  defp leaks_secret?(value) when is_tuple(value), do: value |> Tuple.to_list() |> leaks_secret?()
+  defp leaks_secret?(_value), do: false
+end

--- a/test/ash_introspection/rpc/errors_handler_failure_test.exs
+++ b/test/ash_introspection/rpc/errors_handler_failure_test.exs
@@ -13,7 +13,7 @@ defmodule AshIntrospection.Rpc.ErrorsHandlerFailureTest do
   Handlers are usually written as a function head matching the error shapes the
   developer anticipated, so an unanticipated shape raises `FunctionClauseError`
   rather than being passed through deliberately. These tests pin the closed
-  behaviour for a handler that raises.
+  behaviour for a handler that raises, throws and exits.
   """
   use ExUnit.Case, async: true
 
@@ -32,6 +32,16 @@ defmodule AshIntrospection.Rpc.ErrorsHandlerFailureTest do
     # No clause for any other error type -> FunctionClauseError.
   end
 
+  defmodule ThrowingHandler do
+    @moduledoc false
+    def handle_rpc_error(_error, _context), do: throw(:handler_bailed)
+  end
+
+  defmodule ExitingHandler do
+    @moduledoc false
+    def handle_rpc_error(_error, _context), do: exit(:handler_gave_up)
+  end
+
   describe "a handler that succeeds" do
     test "redacts the error class it matches" do
       [response] = to_errors(RaisingHandler, invalid_attribute())
@@ -44,6 +54,14 @@ defmodule AshIntrospection.Rpc.ErrorsHandlerFailureTest do
   describe "a handler that crashes" do
     test "returns a generic error when the handler raises" do
       assert_fails_closed(RaisingHandler)
+    end
+
+    test "returns a generic error when the handler throws" do
+      assert_fails_closed(ThrowingHandler)
+    end
+
+    test "returns a generic error when the handler exits" do
+      assert_fails_closed(ExitingHandler)
     end
   end
 
@@ -60,6 +78,18 @@ defmodule AshIntrospection.Rpc.ErrorsHandlerFailureTest do
       assert log =~ inspect(RaisingHandler)
       assert log =~ "FunctionClauseError"
       assert log =~ @secret
+    end
+
+    test "names the kind and reason for a handler that throws" do
+      {_response, log} = with_log(fn -> to_errors(ThrowingHandler, invalid_argument()) end)
+
+      assert log =~ "throw: :handler_bailed"
+    end
+
+    test "names the kind and reason for a handler that exits" do
+      {_response, log} = with_log(fn -> to_errors(ExitingHandler, invalid_argument()) end)
+
+      assert log =~ "exit: :handler_gave_up"
     end
   end
 


### PR DESCRIPTION
Closes #12

Ports upstream `ash_typescript` `59d8e98` (CVE-2026-77950).

## Why this path is different

A configured error handler is the application's **only** hook for redacting an
error before it reaches the client. Every other place that fails open leaks
whatever the code happened to be holding; this one leaks precisely the thing
someone wrote code to hide.

Handlers are written the way `RaisingHandler` in the new test is written — a
function head matching the error shapes the developer anticipated. An
unanticipated shape raises `FunctionClauseError`. Before this PR the `rescue`
clause in `apply_error_handler/3` ended with a bare `error`, so that
`FunctionClauseError` returned the **unredacted** error the handler existed to
sanitise. There was no `catch` clause at all, so a handler that threw or exited
unwound past `to_errors/6` entirely and the caller got the handler's crash
instead of any error response.

Latent today, not live: nothing in this repo reaches the handler path.
`ErrorBuilder` is the only in-repo caller of `Errors.to_errors/6`
(`error_builder.ex:560`) and passes `domain` and `resource` as `nil`, so both
handler branches are skipped. The module is published on Hex, and #14 will
route the unified error payloads through it.

## What a client gets now

Any handler failure — raise, throw or exit — returns one opaque map:

```elixir
%{
  message: "Something went wrong. Unique error id: 0d5a…-…",
  short_message: "Internal error",
  code: "internal_error",
  vars: %{},
  fields: [],
  path: [],
  error_id: "0d5a…-…"
}
```

`error_id` is the correlation key. The server-side `Logger.error` carries the
same UUID plus the handler MFA, the failure kind and reason, the original
unredacted error, and the stacktrace — so an operator handed nothing but the
`error_id` from a client report can find the real cause in the log.

`path` is deliberately `[]` rather than the original error's path: path
segments are field names, and the handler may have been redacting exactly
those.

## De-duplication

`handle_unimplemented_error/2` spelled the same seven-key generic map out twice
and the fix would have added a third. All three now call
`generic_internal_error/2`. Behaviour is unchanged — the only difference
between the copies was `path`, which is the argument.

## Deviation from upstream

Upstream's `generic_internal_error/2` uses `type:`. This module's existing
generic errors use `code:`, so this port keeps `code:` to stay a pure fix. Note
that `AshIntrospection.Rpc.Error` protocol implementations already emit `type:`
while `errors.ex` emits `code:` — the inconsistency #14 exists to resolve. This
PR does not touch it, so #13 and #14 merge cleanly on top.

## Test plan

New file `test/ash_introspection/rpc/errors_handler_failure_test.exs`, driven
through the public `Errors.to_errors/6` using the resource-level
`handle_rpc_error/2` hook. It asserts on the payload a client would receive and
scans it recursively — maps, structs, lists, tuples, atoms and binaries — for
a sentinel from the original error, rather than trusting `inspect/1`.

- a handler that succeeds still redacts the class it matches
- a handler that **raises** returns the opaque error and does not leak the
  sentinel
- a handler that **throws** does the same
- a handler that **exits** does the same
- the log carries the `error_id` the client was given
- the log carries the handler, the failure and the original error
- the log names `throw: :handler_bailed` / `exit: :handler_gave_up`

Commands and results, run in the ticket worktree:

| Command | Result |
| --- | --- |
| `mix compile --force` | 0 warnings |
| `mix test` | 181 tests, 0 failures (`main` had 173; this adds 8) |
| `mix format --check-formatted lib/ash_introspection/rpc/errors.ex test/ash_introspection/rpc/errors_handler_failure_test.exs` | test file clean; the only unformatted regions in `errors.ex` are pre-existing on `main` (#30) and untouched here |

There is no CI (#32), so that local run is the gate.
