### PR TITLE
fix: JSON-safe serialization for RPC error payloads

### DIFF
--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -285,6 +285,7 @@ defmodule AshIntrospection.Rpc.Errors do
 
   # Formats field names in error structures for client consumption.
   # Applies resource-level field_names mappings (if resource is known) and output formatter.
+  # Serializes the result so the payload is JSON-encodable - see serialize_error/1.
   defp format_error_field_names(error, resource, config) when is_map(error) do
     formatter = Map.get(config, :output_field_formatter, :camel_case)
     field_formatter_module = Map.get(config, :field_formatter_module, AshIntrospection.FieldFormatter)
@@ -293,6 +294,7 @@ defmodule AshIntrospection.Rpc.Errors do
     |> format_fields_array(resource, formatter, field_formatter_module, config)
     |> format_path_array(formatter, field_formatter_module)
     |> format_vars_field(resource, formatter, field_formatter_module, config)
+    |> serialize_error()
   end
 
   defp format_error_field_names(error, _resource, _config), do: error
@@ -358,4 +360,58 @@ defmodule AshIntrospection.Rpc.Errors do
   end
 
   defp format_vars_field(error, _resource, _formatter, _field_formatter_module, _config), do: error
+
+  # An error's `vars` and `path` hold whatever the code that raised it put there,
+  # so any Erlang term can reach here. The payload is handed to a JSON encoder,
+  # which raises on anything it has no representation for - the request would then
+  # die at the encoder instead of returning the error. This walks the payload and
+  # reduces every value to something an encoder accepts.
+  defp serialize_error(nil), do: nil
+
+  defp serialize_error(value) when is_binary(value), do: value
+
+  defp serialize_error(value) when is_number(value), do: value
+
+  defp serialize_error(value) when is_boolean(value), do: value
+
+  defp serialize_error(value) when is_atom(value), do: Atom.to_string(value)
+
+  defp serialize_error(value) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.map(&serialize_error/1)
+  end
+
+  defp serialize_error(value) when is_list(value) do
+    cond do
+      value == [] ->
+        []
+
+      Keyword.keyword?(value) ->
+        Enum.into(value, %{}, fn {key, val} ->
+          {to_string(key), serialize_error(val)}
+        end)
+
+      List.ascii_printable?(value) ->
+        List.to_string(value)
+
+      true ->
+        Enum.map(value, &serialize_error/1)
+    end
+  end
+
+  defp serialize_error(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp serialize_error(%Date{} = value), do: Date.to_iso8601(value)
+  defp serialize_error(%Time{} = value), do: Time.to_iso8601(value)
+  defp serialize_error(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+  defp serialize_error(%Decimal{} = value), do: Decimal.to_string(value, :normal)
+  defp serialize_error(%Ash.CiString{} = value), do: Ash.CiString.value(value)
+
+  defp serialize_error(value) when is_map(value) do
+    Enum.into(value, %{}, fn {key, val} ->
+      {key, serialize_error(val)}
+    end)
+  end
+
+  defp serialize_error(value), do: value
 end

--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -407,11 +407,33 @@ defmodule AshIntrospection.Rpc.Errors do
   defp serialize_error(%Decimal{} = value), do: Decimal.to_string(value, :normal)
   defp serialize_error(%Ash.CiString{} = value), do: Ash.CiString.value(value)
 
+  # Structs we have no serialization for are reduced to their module name.
+  # Unwrapping them with Map.from_struct/1 would emit every field to the client,
+  # defeating redaction the struct itself declares - `Ash.ForbiddenField`, for
+  # instance, hides the `original_value` the actor is not allowed to see.
+  defp serialize_error(%module{}) do
+    Logger.warning("""
+    Dropped a #{inspect(module)} value while serializing an RPC error.
+
+    Structs without a known serialization are replaced with their module name so
+    their fields are not disclosed to the client. Convert the value to a string,
+    number, or plain map before putting it in an error's `vars` or `path`.
+    """)
+
+    opaque_term(module)
+  end
+
   defp serialize_error(value) when is_map(value) do
     Enum.into(value, %{}, fn {key, val} ->
       {key, serialize_error(val)}
     end)
   end
 
+  defp serialize_error(value) when is_pid(value), do: opaque_term(PID)
+  defp serialize_error(value) when is_reference(value), do: opaque_term(Reference)
+  defp serialize_error(value) when is_function(value), do: opaque_term(Function)
+
   defp serialize_error(value), do: value
+
+  defp opaque_term(module), do: "##{inspect(module)}<>"
 end

--- a/test/ash_introspection/rpc/errors_json_safety_test.exs
+++ b/test/ash_introspection/rpc/errors_json_safety_test.exs
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ErrorsJsonSafetyTest do
+  @moduledoc """
+  An error's `vars` and `path` come from whatever built the error, so they can
+  hold any Erlang term. The RPC payload is handed to a JSON encoder, which
+  raises on anything it has no representation for - the request then dies at
+  the encoder instead of returning the error.
+
+  These tests pin the last step of the error pipeline: whatever reaches the
+  client is JSON-encodable.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.Errors
+
+  describe "values that already have a representation" do
+    test "keeps binaries, numbers and booleans" do
+      vars = vars_of(name: "Ada", count: 3, ratio: 1.5, active: true)
+
+      assert vars[:name] == "Ada"
+      assert vars[:count] == 3
+      assert vars[:ratio] == 1.5
+      assert vars[:active] == true
+    end
+
+    test "stringifies atoms" do
+      assert vars_of(status: :archived)[:status] == "archived"
+    end
+
+    test "turns a tuple into a list" do
+      assert vars_of(pair: {:timeout, 500})[:pair] == ["timeout", 500]
+    end
+
+    test "turns a keyword list into a map" do
+      assert vars_of(opts: [retries: 2])[:opts] == %{"retries" => 2}
+    end
+
+    test "walks a nested map" do
+      assert vars_of(limits: %{max: 10})[:limits] == %{max: 10}
+    end
+
+    test "renders dates and times as iso8601" do
+      vars = vars_of(at: ~U[2026-02-14 01:02:03Z], on: ~D[2026-02-14])
+
+      assert vars[:at] == "2026-02-14T01:02:03Z"
+      assert vars[:on] == "2026-02-14"
+    end
+
+    test "renders a decimal as a plain string" do
+      assert vars_of(amount: Decimal.new("10.50"))[:amount] == "10.50"
+    end
+
+    test "renders an Ash.CiString as its value" do
+      assert vars_of(email: Ash.CiString.new("Ada@Example.com"))[:email] == "Ada@Example.com"
+    end
+
+    test "encodes the whole payload as JSON" do
+      [response] = to_errors(error(vars: [pair: {:timeout, 500}, at: ~U[2026-02-14 01:02:03Z]]))
+
+      assert is_binary(JSON.encode!(response))
+    end
+  end
+
+  defp vars_of(vars) do
+    [response] = to_errors(error(vars: vars))
+
+    response.vars
+  end
+
+  defp error(opts) do
+    [field: :profile, message: "invalid"]
+    |> Keyword.merge(opts)
+    |> Ash.Error.Changes.InvalidAttribute.exception()
+  end
+
+  defp to_errors(error), do: Errors.to_errors(error, nil, nil, nil, %{}, %{})
+end

--- a/test/ash_introspection/rpc/errors_json_safety_test.exs
+++ b/test/ash_introspection/rpc/errors_json_safety_test.exs
@@ -25,6 +25,11 @@ defmodule AshIntrospection.Rpc.ErrorsJsonSafetyTest do
 
   alias AshIntrospection.Rpc.Errors
 
+  # Encodability is asserted with Jason, not the stdlib `JSON` module. `mix.exs`
+  # declares `elixir: "~> 1.15"` and `JSON` only exists from 1.18, so `JSON` here
+  # would fail to compile on a supported version. Ash depends on Jason
+  # non-optionally, so it is always available.
+
   @secret "sk_live_do_not_disclose"
 
   defmodule Envelope do
@@ -96,7 +101,7 @@ defmodule AshIntrospection.Rpc.ErrorsJsonSafetyTest do
           )
         end)
 
-      assert is_binary(JSON.encode!(response))
+      assert is_binary(Jason.encode!(response))
       refute leaks_secret?(response)
     end
   end
@@ -145,7 +150,7 @@ defmodule AshIntrospection.Rpc.ErrorsJsonSafetyTest do
     test "encodes the whole payload as JSON" do
       [response] = to_errors(error(vars: [pair: {:timeout, 500}, at: ~U[2026-02-14 01:02:03Z]]))
 
-      assert is_binary(JSON.encode!(response))
+      assert is_binary(Jason.encode!(response))
     end
   end
 

--- a/test/ash_introspection/rpc/errors_json_safety_test.exs
+++ b/test/ash_introspection/rpc/errors_json_safety_test.exs
@@ -5,16 +5,101 @@
 defmodule AshIntrospection.Rpc.ErrorsJsonSafetyTest do
   @moduledoc """
   An error's `vars` and `path` come from whatever built the error, so they can
-  hold any Erlang term. The RPC payload is handed to a JSON encoder, which
-  raises on anything it has no representation for - the request then dies at
-  the encoder instead of returning the error.
+  hold any Erlang term - a PID from a process that failed, a monitor
+  reference, a callback, an internal struct. The RPC payload is handed to a
+  JSON encoder, which raises on anything it has no representation for: the
+  request then dies at the encoder instead of returning the error.
+
+  Unwrapping a struct into its fields is the other half of the problem. It
+  encodes, but it discloses every field the struct carries, including the ones
+  the struct hides from `Inspect` precisely because the client must not see
+  them.
 
   These tests pin the last step of the error pipeline: whatever reaches the
-  client is JSON-encodable.
+  client is JSON-encodable, and terms with no safe representation are reduced
+  to an opaque marker rather than unwrapped.
   """
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias AshIntrospection.Rpc.Errors
+
+  @secret "sk_live_do_not_disclose"
+
+  defmodule Envelope do
+    @moduledoc false
+    defstruct [:label, :token]
+  end
+
+  describe "terms with no JSON representation" do
+    test "replaces a pid with an opaque term" do
+      assert vars_of(pid: self())[:pid] == "#PID<>"
+    end
+
+    test "replaces a reference with an opaque term" do
+      assert vars_of(ref: make_ref())[:ref] == "#Reference<>"
+    end
+
+    test "replaces an anonymous function with an opaque term" do
+      assert vars_of(fun: fn -> :ok end)[:fun] == "#Function<>"
+    end
+
+    test "replaces a pid in the error path with an opaque term" do
+      [response] = to_errors(error(path: [:profile, self()]))
+
+      assert response.path == ["profile", "#PID<>"]
+    end
+  end
+
+  describe "an unknown struct" do
+    test "is reduced to its module name" do
+      {vars, _log} =
+        with_log(fn -> vars_of(envelope: %Envelope{label: "api key", token: @secret}) end)
+
+      assert vars[:envelope] == "##{inspect(Envelope)}<>"
+    end
+
+    test "does not disclose the fields it carries" do
+      {[response], _log} =
+        with_log(fn -> to_errors(error(vars: [envelope: %Envelope{token: @secret}])) end)
+
+      refute leaks_secret?(response)
+    end
+
+    test "is logged with the module that was dropped" do
+      {_response, log} =
+        with_log(fn -> to_errors(error(vars: [envelope: %Envelope{token: @secret}])) end)
+
+      assert log =~ inspect(Envelope)
+      assert log =~ "serializing an RPC error"
+      refute log =~ @secret
+    end
+  end
+
+  describe "the payload handed to the client" do
+    test "encodes as JSON with every unencodable term present" do
+      {[response], _log} =
+        with_log(fn ->
+          to_errors(
+            error(
+              vars: [
+                pid: self(),
+                ref: make_ref(),
+                fun: fn -> :ok end,
+                envelope: %Envelope{token: @secret},
+                nested: %{deeper: [self()]},
+                pair: {:timeout, 500}
+              ],
+              path: [:profile, self()]
+            )
+          )
+        end)
+
+      assert is_binary(JSON.encode!(response))
+      refute leaks_secret?(response)
+    end
+  end
 
   describe "values that already have a representation" do
     test "keeps binaries, numbers and booleans" do
@@ -77,4 +162,16 @@ defmodule AshIntrospection.Rpc.ErrorsJsonSafetyTest do
   end
 
   defp to_errors(error), do: Errors.to_errors(error, nil, nil, nil, %{}, %{})
+
+  defp leaks_secret?(value) when is_binary(value), do: String.contains?(value, @secret)
+  defp leaks_secret?(value) when is_atom(value), do: leaks_secret?(Atom.to_string(value))
+  defp leaks_secret?(%_{} = value), do: value |> Map.from_struct() |> leaks_secret?()
+
+  defp leaks_secret?(value) when is_map(value) do
+    Enum.any?(value, fn {key, val} -> leaks_secret?(key) or leaks_secret?(val) end)
+  end
+
+  defp leaks_secret?(value) when is_list(value), do: Enum.any?(value, &leaks_secret?/1)
+  defp leaks_secret?(value) when is_tuple(value), do: value |> Tuple.to_list() |> leaks_secret?()
+  defp leaks_secret?(_value), do: false
 end


### PR DESCRIPTION
Closes #13

## Summary

The RPC error path had no JSON-safety pass. `format_error_field_names/3`
formatted field names and returned, so `vars` and `path` reached the client
carrying whatever term the raising code put there. This ports the two upstream
commits named in the ticket: `8749c7a` (the recursive `serialize_error/1`
ladder) and `c3f2961` (the struct, PID, reference and function clauses).

`serialize_error/1` runs as the last step of `format_error_field_names/3`. It
is a dedicated private function in `rpc/errors.ex`, not a call into
`ResultProcessor` — upstream tried that route in `fce9528` and replaced it,
and in this repo that alias is dead code delegating to `normalize_primitive/1`.
The error path stays independent.

## What could reach a client before

`vars` and `path` were handed to the JSON encoder untouched. Anything the
raising code put there arrived as-is:

| Term | Before | Now |
| --- | --- | --- |
| PID | raw `#PID<0.287.0>` — encoder raises | `"#PID<>"` |
| Reference | raw ref — encoder raises | `"#Reference<>"` |
| Anonymous function | raw fun — encoder raises | `"#Function<>"` |
| Unknown struct | walked as a plain map, every field disclosed | `"#MyApp.Envelope<>"` + a `Logger.warning` naming the module |
| Tuple | raw tuple — encoder raises | list of serialized elements |
| Atom | raw atom | string |
| Keyword list | raw keyword list — encoder raises | map with string keys |
| Charlist | list of integers | the string |
| `DateTime`/`Date`/`Time`/`NaiveDateTime` | struct | ISO 8601 string |
| `Decimal` | struct | `"10.50"` |
| `Ash.CiString` | struct | the underlying string |

Two distinct failures fixed. A PID, ref, function, tuple or keyword list made the
JSON encoder raise, so the request died at the encoder instead of returning
the error. An unknown struct did encode — by disclosing every field it
carried, which defeats redaction the struct itself declares. `Ash.ForbiddenField`
hides `original_value` from `Inspect` precisely because the actor is not allowed
to see it; unwrapping it with `Map.from_struct/1` handed it over.

## Scope

Only `lib/ash_introspection/rpc/errors.ex` and one new test file. The `type:`
vs `code:` inconsistency (#14) is untouched — the new pass emits whatever the
current code emits, so #14 merges cleanly. #40 is untouched. No pre-existing
formatter churn was committed: `mix format` reformats six unrelated spots in
`errors.ex` because `main` is not formatter-clean (#30), and those were reverted
so the diff is the change alone.

## Test plan

New file `test/ash_introspection/rpc/errors_json_safety_test.exs`, 17 tests,
driven through the public `Errors.to_errors/6` — no private function is called
directly. The payload is genuinely encoded with `Jason.encode!/1` rather than
eyeballed, and a sentinel value planted in an unknown struct's field is scanned
for recursively across the whole response and the log.

```
mix test
# 207 tests, 0 failures  (main was 190)

mix compile --force --warnings-as-errors
# Generated ash_introspection app — no warnings

mix format --check-formatted lib/ash_introspection/rpc/errors.ex \
  test/ash_introspection/rpc/errors_json_safety_test.exs
# fails only on pre-existing lines in errors.ex (#30); nothing in the new code
```

Both behaviour commits were verified red before green: the ladder commit's tests
failed 14 of 16 against `main`, and the struct/PID commit's tests failed 8 of 17
against the ladder alone.

## Elixir version floor

Encodability is asserted with `Jason.encode!/1`, not the stdlib `JSON` module.
`mix.exs` declares `elixir: "~> 1.15"` and `JSON` only exists from 1.18, so
`JSON` here would fail to compile on a supported version — and the CI matrix
landing under #32 may include one. Jason adds no dependency: `ash` depends on it
non-optionally, and `error_detail_leak_test.exs` already uses it for the same
assertion. The reason is recorded in a comment next to the alias. Raising the
`elixir` floor is a bigger decision than this PR should make; it belongs in its
own ticket if anyone wants it.
