### PR TITLE
fix: preserve false values in plain map fields and named identity filters

### DIFF
--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -566,9 +566,19 @@ defmodule AshIntrospection.Rpc.Pipeline do
     end
   end
 
+  # `Map.fetch/2` rather than `Map.get/2 || Map.get/2`: a boolean identity key
+  # valued `false` is falsy, so the `||` discarded it and the filter became
+  # `key == nil`. The update or destroy then ran against a record the caller
+  # never named, or against none at all.
   defp build_named_identity_filter(identity, parsed_identity) when is_map(parsed_identity) do
     Enum.map(identity.keys, fn key ->
-      {key, Map.get(parsed_identity, key) || Map.get(parsed_identity, Atom.to_string(key))}
+      value =
+        case Map.fetch(parsed_identity, key) do
+          {:ok, value} -> value
+          :error -> Map.get(parsed_identity, Atom.to_string(key))
+        end
+
+      {key, value}
     end)
   end
 

--- a/lib/ash_introspection/rpc/result_processor.ex
+++ b/lib/ash_introspection/rpc/result_processor.ex
@@ -494,11 +494,11 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
     Enum.reduce(template, %{}, fn field_spec, acc ->
       case field_spec do
         field_atom when is_atom(field_atom) ->
-          field_value = Map.get(value, field_atom) || Map.get(value, to_string(field_atom))
+          field_value = plain_map_field(value, field_atom)
           Map.put(acc, field_atom, normalize_primitive(field_value))
 
         {field_atom, nested_template} when is_atom(field_atom) ->
-          field_value = Map.get(value, field_atom) || Map.get(value, to_string(field_atom))
+          field_value = plain_map_field(value, field_atom)
 
           nested_extracted =
             if is_map(field_value) and nested_template != [] do
@@ -513,6 +513,18 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
           acc
       end
     end)
+  end
+
+  # Untyped maps reach us with either atom or string keys, so both forms are
+  # tried. `Map.fetch/2` rather than `Map.get/2 || Map.get/2`: a field present
+  # and `false` (or `nil`) is falsy, so `||` hands the lookup to the string key
+  # and reports the field as absent. The client then receives `nil` for a value
+  # that was legitimately `false`.
+  defp plain_map_field(map, field_atom) do
+    case Map.fetch(map, field_atom) do
+      {:ok, value} -> value
+      :error -> Map.get(map, to_string(field_atom))
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────

--- a/test/ash_introspection/rpc/pipeline_identity_boolean_test.exs
+++ b/test/ash_introspection/rpc/pipeline_identity_boolean_test.exs
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineIdentityBooleanTest do
+  @moduledoc """
+  Pins named-identity lookups against a `false` identity value collapsing to
+  `nil`.
+
+  `build_named_identity_filter/2` read each key with
+  `Map.get(identity, key) || Map.get(identity, to_string(key))`. `false` is
+  falsy, so the `||` discarded it and the filter became `active == nil` — a
+  predicate the caller never asked for, which resolves to the wrong record or
+  to none at all. Identities drive `execute_update_action/3`
+  and `execute_destroy_action/3` (reads use `get_by`), so these tests exercise
+  those two against three accounts that differ only in `:active` — `false`,
+  `true` and `nil` — and assert which record changed and which did not.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.Account
+  alias AshIntrospection.Test.RpcDomain
+
+  setup do
+    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
+
+    suffix = System.unique_integer([:positive])
+    name = "Shared-#{suffix}"
+
+    accounts =
+      Map.new([{:inactive, false}, {:active, true}, {:unset, nil}], fn {label, active} ->
+        account =
+          Account
+          |> Ash.Changeset.for_create(:create, %{
+            name: name,
+            email: "#{label}-#{suffix}@example.com",
+            active: active
+          })
+          |> Ash.create!()
+
+        {label, account}
+      end)
+
+    Map.put(accounts, :name, name)
+  end
+
+  defp update_request(identity, input) do
+    Request.new(%{
+      domain: RpcDomain,
+      resource: Account,
+      action: Ash.Resource.Info.action(Account, :update),
+      rpc_action: %{identities: [:unique_name_active]},
+      input: input,
+      context: %{},
+      select: [:id, :name, :email, :active],
+      load: [],
+      extraction_template: [:id, :name, :email, :active],
+      identity: identity
+    })
+  end
+
+  defp destroy_request(identity) do
+    Request.new(%{
+      domain: RpcDomain,
+      resource: Account,
+      action: Ash.Resource.Info.action(Account, :destroy),
+      rpc_action: %{identities: [:unique_name_active]},
+      input: %{},
+      context: %{},
+      select: [:id, :name, :email, :active],
+      load: [],
+      extraction_template: [:id, :name, :email, :active],
+      identity: identity
+    })
+  end
+
+  defp emails(ctx) do
+    Map.new([:inactive, :active, :unset], fn label ->
+      {label, Ash.get!(Account, Map.fetch!(ctx, label).id).email}
+    end)
+  end
+
+  describe "updates through a boolean named identity" do
+    test "an identity value of false updates the false record and nothing else",
+         %{name: name} = ctx do
+      assert {:ok, record} =
+               Pipeline.execute_ash_action(
+                 update_request(%{name: name, active: false}, %{email: "renamed@example.com"})
+               )
+
+      assert record.id == ctx.inactive.id
+
+      assert %{inactive: "renamed@example.com", active: ctx.active.email, unset: ctx.unset.email} ==
+               emails(ctx)
+    end
+
+    test "an identity value of true updates the true record and nothing else",
+         %{name: name} = ctx do
+      assert {:ok, record} =
+               Pipeline.execute_ash_action(
+                 update_request(%{name: name, active: true}, %{email: "renamed@example.com"})
+               )
+
+      assert record.id == ctx.active.id
+
+      assert %{
+               inactive: ctx.inactive.email,
+               active: "renamed@example.com",
+               unset: ctx.unset.email
+             } ==
+               emails(ctx)
+    end
+
+    test "an identity value of nil never resolves the false record", %{name: name} = ctx do
+      # `false` and `nil` must not be interchangeable. A nil identity value
+      # compiles to `active == nil`, which Ash evaluates as unknown and so
+      # matches no record — that is a separate concern from this fix, and the
+      # point here is only that it does not reach the `active: false` account.
+      assert {:error, %Ash.Error.Query.NotFound{}} =
+               Pipeline.execute_ash_action(
+                 update_request(%{name: name, active: nil}, %{email: "renamed@example.com"})
+               )
+
+      assert %{inactive: ctx.inactive.email, active: ctx.active.email, unset: ctx.unset.email} ==
+               emails(ctx)
+    end
+  end
+
+  describe "destroys through a boolean named identity" do
+    test "an identity value of false destroys the false record and nothing else",
+         %{name: name} = ctx do
+      assert {:ok, _} = Pipeline.execute_ash_action(destroy_request(%{name: name, active: false}))
+
+      assert {:error, _} = Ash.get(Account, ctx.inactive.id)
+      assert Ash.get!(Account, ctx.active.id)
+      assert Ash.get!(Account, ctx.unset.id)
+    end
+  end
+end

--- a/test/ash_introspection/rpc/result_processor_plain_map_test.exs
+++ b/test/ash_introspection/rpc/result_processor_plain_map_test.exs
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ResultProcessorPlainMapTest do
+  @moduledoc """
+  Pins the untyped-map extraction path against a `false` field arriving at the
+  client as `nil`.
+
+  `Map.get(map, :field) || Map.get(map, "field")` cannot tell a field that is
+  present and `false` from one that is absent: a falsy left side always hands
+  the lookup to the string key, so a legitimate `false` is reported as `nil`.
+  `Map.fetch/2` separates the three cases a client cares about — present and
+  `false`, present and `nil`, absent — and these tests drive all three through
+  `ResultProcessor.process/4`, the value the client actually receives.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.ResultProcessor
+
+  describe "untyped map fields" do
+    test "a field present and false stays false" do
+      assert %{enabled: false} == ResultProcessor.process(%{enabled: false}, [:enabled])
+    end
+
+    test "a field present and false under a string key stays false" do
+      assert %{enabled: false} == ResultProcessor.process(%{"enabled" => false}, [:enabled])
+    end
+
+    test "an atom key holding false wins over a string key holding true" do
+      # The discriminator: `||` returns the string key's `true` here, so a test
+      # that only asserts `false` on a single-key map would pass a sloppy fix.
+      assert %{enabled: false} ==
+               ResultProcessor.process(%{:enabled => false, "enabled" => true}, [:enabled])
+    end
+
+    test "a field present and nil stays nil rather than falling back to the string key" do
+      assert %{enabled: nil} ==
+               ResultProcessor.process(%{:enabled => nil, "enabled" => true}, [:enabled])
+    end
+
+    test "an absent atom key still falls back to the string key" do
+      assert %{count: 3} == ResultProcessor.process(%{"count" => 3}, [:count])
+    end
+
+    test "a field absent from both key forms is nil" do
+      assert %{enabled: nil} == ResultProcessor.process(%{other: 1}, [:enabled])
+    end
+  end
+
+  describe "untyped map fields under a nested template" do
+    test "a nested field present and false stays false" do
+      assert %{settings: %{enabled: false}} ==
+               ResultProcessor.process(%{settings: %{enabled: false}}, [{:settings, [:enabled]}])
+    end
+
+    test "an atom key holding false wins over a string key holding a nested map" do
+      assert %{settings: false} ==
+               ResultProcessor.process(
+                 %{:settings => false, "settings" => %{enabled: true}},
+                 [{:settings, [:enabled]}]
+               )
+    end
+
+    test "a nested atom key holding nil stays nil rather than falling back" do
+      assert %{settings: nil} ==
+               ResultProcessor.process(
+                 %{:settings => nil, "settings" => %{enabled: true}},
+                 [{:settings, [:enabled]}]
+               )
+    end
+
+    test "an absent nested atom key still falls back to the string key" do
+      assert %{settings: %{enabled: true}} ==
+               ResultProcessor.process(%{"settings" => %{enabled: true}}, [
+                 {:settings, [:enabled]}
+               ])
+    end
+  end
+end

--- a/test/support/rpc_resources.ex
+++ b/test/support/rpc_resources.ex
@@ -18,6 +18,10 @@ defmodule AshIntrospection.Test.Account do
   Carries a named identity (`:unique_email`) plus a `get?` read action so the
   pipeline's two trusted-filter paths — `maybe_apply_identity_filter/5` and
   `apply_get_by_filter/3` — can both be driven end to end.
+
+  `:active` is a boolean identity key (`:unique_name_active`) because an
+  identity value of `false` is the case a `Map.get/2 || Map.get/2` lookup
+  silently turns into `nil`, resolving the filter against the wrong record.
   """
   use Ash.Resource,
     domain: AshIntrospection.Test.RpcDomain,
@@ -27,10 +31,15 @@ defmodule AshIntrospection.Test.Account do
     uuid_primary_key(:id)
     attribute(:name, :string, allow_nil?: false, public?: true)
     attribute(:email, :string, allow_nil?: false, public?: true)
+    attribute(:active, :boolean, public?: true)
   end
 
   identities do
     identity(:unique_email, [:email], pre_check_with: AshIntrospection.Test.RpcDomain)
+
+    identity(:unique_name_active, [:name, :active],
+      pre_check_with: AshIntrospection.Test.RpcDomain
+    )
   end
 
   actions do


### PR DESCRIPTION
Closes #15

## Summary

`Map.get(map, :field) || Map.get(map, "field")` cannot tell a field that is
present and `false` from one that is absent. `false` is falsy, so the `||`
always hands the lookup to the string-key form and the caller gets `nil`.

Two sites carried the pattern. Both now use `Map.fetch/2`, which keeps a
present key's value whatever it is and falls back to the string key only when
the atom key is genuinely absent.

- `AshIntrospection.Rpc.ResultProcessor.extract_plain_map_value/2` — both the
  bare-atom and the nested-template branch, extracted into a
  `plain_map_field/2` helper. A `false` field in an untyped map reached the
  client as `nil`.
- `AshIntrospection.Rpc.Pipeline.build_named_identity_filter/2` — a boolean
  identity key valued `false` became `key == nil`, so an update or destroy ran
  against a record the caller never named, or against none.

Ported from upstream `ash_typescript` `584960f` and the `Map.fetch` identity
change in `8ed1fbb`. The `code` → `type` error rename that `8ed1fbb` also
carries is #14 and is not in this PR.

## Before / after

Untyped map field, `ResultProcessor.process(%{enabled: false}, [:enabled])`:

| | result |
| --- | --- |
| before | `%{enabled: nil}` |
| after | `%{enabled: false}` |

Boolean named identity, update with `%{name: "Shared", active: false}` against
three accounts that differ only in `:active`:

| | result |
| --- | --- |
| before | filter is `active == nil`; `Ash.Error.Query.NotFound`, no record updated |
| after | the `active: false` account is updated; the other two are untouched |

## The three cases now distinguished

`Map.fetch/2` separates what `||` conflated:

| case | before | after |
| --- | --- | --- |
| atom key present, value `false` | string key's value, else `nil` | `false` |
| atom key present, value `nil` | string key's value, else `nil` | `nil` |
| atom key absent | string key's value, else `nil` | string key's value, else `nil` |

The discriminating tests set both key forms on one map — `%{:enabled => false,
"enabled" => true}` — so a fix that only special-cased `false` would still
fail.

## Test plan

New tests, both written failing first:

- `test/ash_introspection/rpc/result_processor_plain_map_test.exs` — 10 tests
  through `ResultProcessor.process/4`, the value a client receives. Covers all
  three cases, flat and nested. 6 of the 10 failed before the fix.
- `test/ash_introspection/rpc/pipeline_identity_boolean_test.exs` — 4 tests
  through `Pipeline.execute_ash_action/1` on update and destroy, against three
  accounts differing only in `:active`. Asserts which record changed and which
  did not. 2 of the 4 failed before the fix.

The `Account` fixture in `test/support/rpc_resources.ex` gains an `:active`
boolean attribute and the `:unique_name_active` identity.

Commands:

- `mix test` — 221 tests, 0 failures (`main` is 207, so +14, none regressed)
- `mix compile --force` — no warnings
- `mix format --check-formatted` on the touched files reports only regions
  that were already unformatted on `main` (#30); nothing new was reformatted.

## Noted, not fixed here

- An identity value of `nil` compiles to `key == nil`, which Ash evaluates as
  unknown, so it matches no record. Unchanged by this PR and pinned by a test.
  Arguably it should compile to `is_nil(key)`.
- `build_named_identity_filter/2`'s string-key fallback is unreachable through
  the current caller: `build_identity_filter/3` selects the identity only when
  `Map.has_key?/2` is true for every atom key. Kept for upstream parity.
- `lib/ash_introspection/rpc/field_processing/field_selector.ex:910` and `:925`
  carry the same `||` pattern for `:args` and `:fields`. Those values are lists
  or maps rather than booleans, so the bug does not bite today.
