### PR TITLE
chore: teach the formatter about the Ash and Spark DSLs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:ash, :spark],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/lib/ash_introspection/codegen/action_introspection.ex
+++ b/lib/ash_introspection/codegen/action_introspection.ex
@@ -258,8 +258,8 @@ defmodule AshIntrospection.Codegen.ActionIntrospection do
 
       %Ash.Resource.Attribute{} = input ->
         input.name not in Map.get(action, :allow_nil_input, []) and
-            (input.name in Map.get(action, :require_attributes, []) ||
-               (not input.allow_nil? and is_nil(input.default)))
+          (input.name in Map.get(action, :require_attributes, []) ||
+             (not input.allow_nil? and is_nil(input.default)))
     end)
     |> Enum.map(& &1.name)
   end
@@ -287,8 +287,8 @@ defmodule AshIntrospection.Codegen.ActionIntrospection do
 
       %Ash.Resource.Attribute{} = input ->
         input.name not in Map.get(action, :allow_nil_input, []) and
-            (input.name in Map.get(action, :require_attributes, []) ||
-               (not input.allow_nil? and is_nil(input.default)))
+          (input.name in Map.get(action, :require_attributes, []) ||
+             (not input.allow_nil? and is_nil(input.default)))
     end)
     |> Enum.map(& &1.name)
   end

--- a/lib/ash_introspection/codegen/validation_error_types.ex
+++ b/lib/ash_introspection/codegen/validation_error_types.ex
@@ -145,7 +145,9 @@ defmodule AshIntrospection.Codegen.ValidationErrorTypes do
 
         # Union types
         unwrapped_type == Ash.Type.Union ->
-          union_types = Introspection.get_union_types_from_constraints(unwrapped_type, full_constraints)
+          union_types =
+            Introspection.get_union_types_from_constraints(unwrapped_type, full_constraints)
+
           member_classifications = classify_union_members(union_types)
           {:union_errors, member_classifications}
 

--- a/lib/ash_introspection/rpc/error_builder.ex
+++ b/lib/ash_introspection/rpc/error_builder.ex
@@ -44,7 +44,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
 
   def build_error_response(error, config) do
     formatter = Map.get(config, :output_field_formatter, :camel_case)
-    field_formatter_module = Map.get(config, :field_formatter_module, AshIntrospection.FieldFormatter)
+
+    field_formatter_module =
+      Map.get(config, :field_formatter_module, AshIntrospection.FieldFormatter)
 
     do_build_error_response(error, formatter, field_formatter_module, config)
   end
@@ -88,7 +90,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
       # === FIELD VALIDATION ERRORS WITH FIELD PATHS ===
 
       {:unknown_field, field_atom, "map", path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -105,7 +109,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
         }
 
       {:unknown_field, field_atom, "union_attribute", path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -123,7 +129,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
         }
 
       {:unknown_field, field_atom, resource, path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -141,7 +149,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
         }
 
       {:calculation_requires_args, field_atom, path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -158,7 +168,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
         }
 
       {:invalid_calculation_args, field_atom, path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -176,7 +188,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
 
       {:requires_field_selection, field_type, field_name, path}
       when is_list(path) and is_atom(field_name) ->
-        full_field_path = build_complete_field_path(path, field_name, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_name, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -213,7 +227,10 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
 
       {:invalid_field_selection, field_atom, field_type, path} when is_list(path) ->
         field_type_string = format_field_type(field_type)
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -264,7 +281,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
         }
 
       {:field_does_not_support_nesting, field_name, path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_name, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_name, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -281,7 +300,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
         }
 
       {:duplicate_field, field_atom, path} when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -299,7 +320,9 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
 
       {:unsupported_field_combination, field_type, field_atom, field_spec, path}
       when is_list(path) ->
-        full_field_path = build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+        full_field_path =
+          build_complete_field_path(path, field_atom, formatter, field_formatter_module)
+
         formatted_path = format_path(path, formatter, field_formatter_module)
 
         %{
@@ -563,7 +586,10 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
 
       {:invalid_field_type, field_name, path} ->
         formatted_path = format_path(path, formatter, field_formatter_module)
-        formatted_field = apply(field_formatter_module, :format_field_name, [to_string(field_name), formatter])
+
+        formatted_field =
+          apply(field_formatter_module, :format_field_name, [to_string(field_name), formatter])
+
         field_path = Enum.join(formatted_path ++ [formatted_field], ".")
 
         %{
@@ -619,15 +645,18 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
     end)
   end
 
-  defp format_field_name(field_name, formatter, field_formatter_module) when is_atom(field_name) do
+  defp format_field_name(field_name, formatter, field_formatter_module)
+       when is_atom(field_name) do
     format_field_name(to_string(field_name), formatter, field_formatter_module)
   end
 
-  defp format_field_name(field_name, formatter, field_formatter_module) when is_binary(field_name) do
+  defp format_field_name(field_name, formatter, field_formatter_module)
+       when is_binary(field_name) do
     apply(field_formatter_module, :format_field_name, [field_name, formatter])
   end
 
-  defp build_complete_field_path(path, field_name, formatter, field_formatter_module) when is_list(path) do
+  defp build_complete_field_path(path, field_name, formatter, field_formatter_module)
+       when is_list(path) do
     formatted_path = format_path(path, formatter, field_formatter_module)
     formatted_field = format_field_name(field_name, formatter, field_formatter_module)
 

--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -47,7 +47,14 @@ defmodule AshIntrospection.Rpc.Errors do
   """
   @spec to_errors(term(), module() | nil, module() | nil, atom() | nil, map(), config()) ::
           list(map())
-  def to_errors(errors, domain \\ nil, resource \\ nil, action \\ nil, context \\ %{}, config \\ %{})
+  def to_errors(
+        errors,
+        domain \\ nil,
+        resource \\ nil,
+        action \\ nil,
+        context \\ %{},
+        config \\ %{}
+      )
 
   def to_errors(errors, domain, resource, action, context, config) do
     ash_error = Ash.Error.to_error_class(errors)
@@ -288,7 +295,9 @@ defmodule AshIntrospection.Rpc.Errors do
   # Serializes the result so the payload is JSON-encodable - see serialize_error/1.
   defp format_error_field_names(error, resource, config) when is_map(error) do
     formatter = Map.get(config, :output_field_formatter, :camel_case)
-    field_formatter_module = Map.get(config, :field_formatter_module, AshIntrospection.FieldFormatter)
+
+    field_formatter_module =
+      Map.get(config, :field_formatter_module, AshIntrospection.FieldFormatter)
 
     error
     |> format_fields_array(resource, formatter, field_formatter_module, config)
@@ -299,7 +308,13 @@ defmodule AshIntrospection.Rpc.Errors do
 
   defp format_error_field_names(error, _resource, _config), do: error
 
-  defp format_fields_array(%{fields: fields} = error, resource, formatter, field_formatter_module, config)
+  defp format_fields_array(
+         %{fields: fields} = error,
+         resource,
+         formatter,
+         field_formatter_module,
+         config
+       )
        when is_list(fields) do
     format_field_for_client = Map.get(config, :format_field_for_client)
 
@@ -315,9 +330,11 @@ defmodule AshIntrospection.Rpc.Errors do
     %{error | fields: formatted_fields}
   end
 
-  defp format_fields_array(error, _resource, _formatter, _field_formatter_module, _config), do: error
+  defp format_fields_array(error, _resource, _formatter, _field_formatter_module, _config),
+    do: error
 
-  defp format_path_array(%{path: path} = error, formatter, field_formatter_module) when is_list(path) do
+  defp format_path_array(%{path: path} = error, formatter, field_formatter_module)
+       when is_list(path) do
     # Path segments use simple formatting (no resource-level mappings)
     formatted_path =
       Enum.map(path, fn
@@ -336,7 +353,13 @@ defmodule AshIntrospection.Rpc.Errors do
 
   defp format_path_array(error, _formatter, _field_formatter_module), do: error
 
-  defp format_vars_field(%{vars: vars} = error, resource, formatter, field_formatter_module, config)
+  defp format_vars_field(
+         %{vars: vars} = error,
+         resource,
+         formatter,
+         field_formatter_module,
+         config
+       )
        when is_map(vars) do
     format_field_for_client = Map.get(config, :format_field_for_client)
 
@@ -359,7 +382,8 @@ defmodule AshIntrospection.Rpc.Errors do
     %{error | vars: formatted_vars}
   end
 
-  defp format_vars_field(error, _resource, _formatter, _field_formatter_module, _config), do: error
+  defp format_vars_field(error, _resource, _formatter, _field_formatter_module, _config),
+    do: error
 
   # An error's `vars` and `path` hold whatever the code that raised it put there,
   # so any Erlang term can reach here. The payload is handed to a JSON encoder,

--- a/lib/ash_introspection/rpc/field_processing/atomizer.ex
+++ b/lib/ash_introspection/rpc/field_processing/atomizer.ex
@@ -52,7 +52,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Atomizer do
   @spec atomize_requested_fields(list(), module() | nil, config()) :: list()
   def atomize_requested_fields(requested_fields, resource \\ nil, config \\ %{})
 
-  def atomize_requested_fields(requested_fields, resource, config) when is_list(requested_fields) do
+  def atomize_requested_fields(requested_fields, resource, config)
+      when is_list(requested_fields) do
     formatter = Map.get(config, :input_field_formatter, :camel_case)
     Enum.map(requested_fields, &process_field(&1, formatter, resource, config))
   end
@@ -187,9 +188,16 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Atomizer do
   For field selection lists, preserves strings for type-aware reverse mapping.
   """
   @spec process_field_value(term(), atom(), module() | nil, config(), boolean()) :: term()
-  def process_field_value(value, formatter, resource \\ nil, config \\ %{}, atomize_strings \\ true)
+  def process_field_value(
+        value,
+        formatter,
+        resource \\ nil,
+        config \\ %{},
+        atomize_strings \\ true
+      )
 
-  def process_field_value(list, formatter, resource, config, atomize_strings) when is_list(list) do
+  def process_field_value(list, formatter, resource, config, atomize_strings)
+      when is_list(list) do
     Enum.map(list, fn
       field_name when is_binary(field_name) ->
         if atomize_strings do

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -124,7 +124,9 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   @spec select_fields(atom() | tuple(), keyword(), list(), list(), config()) :: select_result()
   def select_fields(type, constraints, requested_fields, path, config) do
     field_names_callback = Map.get(config, :field_names_callback, :interop_field_names)
-    {unwrapped_type, full_constraints} = Introspection.unwrap_new_type(type, constraints, field_names_callback)
+
+    {unwrapped_type, full_constraints} =
+      Introspection.unwrap_new_type(type, constraints, field_names_callback)
 
     cond do
       match?({:array, _}, type) ->
@@ -199,19 +201,48 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
           Enum.reduce(entries, acc, fn {field_name, nested_fields}, inner_acc ->
             cond do
               is_list(nested_fields) ->
-                process_nested_resource_field(resource, field_name, nested_fields, path, inner_acc, config)
+                process_nested_resource_field(
+                  resource,
+                  field_name,
+                  nested_fields,
+                  path,
+                  inner_acc,
+                  config
+                )
 
               is_map(nested_fields) ->
                 case get_args_and_fields(nested_fields) do
                   {:ok, args, fields} ->
-                    process_calculation_with_args(resource, field_name, args, fields, path, inner_acc, config)
+                    process_calculation_with_args(
+                      resource,
+                      field_name,
+                      args,
+                      fields,
+                      path,
+                      inner_acc,
+                      config
+                    )
 
                   :not_args_structure ->
-                    process_nested_resource_field(resource, field_name, nested_fields, path, inner_acc, config)
+                    process_nested_resource_field(
+                      resource,
+                      field_name,
+                      nested_fields,
+                      path,
+                      inner_acc,
+                      config
+                    )
                 end
 
               true ->
-                process_nested_resource_field(resource, field_name, nested_fields, path, inner_acc, config)
+                process_nested_resource_field(
+                  resource,
+                  field_name,
+                  nested_fields,
+                  path,
+                  inner_acc,
+                  config
+                )
             end
           end)
       end
@@ -242,9 +273,18 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     end
   end
 
-  defp process_nested_resource_field(resource, field_name, nested_fields, path, {select, load, template}, config) do
+  defp process_nested_resource_field(
+         resource,
+         field_name,
+         nested_fields,
+         path,
+         {select, load, template},
+         config
+       ) do
     internal_name = resolve_resource_field_name(resource, field_name, config)
-    {field_type, field_constraints, category} = get_resource_field_info(resource, internal_name, path)
+
+    {field_type, field_constraints, category} =
+      get_resource_field_info(resource, internal_name, path)
 
     if category == :calculation_with_args do
       throw({:invalid_calculation_args, internal_name, path})
@@ -258,11 +298,13 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       throw({:invalid_calculation_args, internal_name, path})
     end
 
-    if category == :calculation && !requires_nested_selection?(field_type, field_constraints, config) do
+    if category == :calculation &&
+         !requires_nested_selection?(field_type, field_constraints, config) do
       throw({:field_does_not_support_nesting, internal_name, path})
     end
 
-    if category == :attribute && !requires_nested_selection?(field_type, field_constraints, config) do
+    if category == :attribute &&
+         !requires_nested_selection?(field_type, field_constraints, config) do
       throw({:field_does_not_support_nesting, internal_name, path})
     end
 
@@ -280,7 +322,14 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       select_fields(field_type, field_constraints, nested_fields, new_path, config)
 
     case category do
-      cat when cat in [:attribute, :embedded_resource, :tuple, :field_constrained_type, :union_attribute] ->
+      cat
+      when cat in [
+             :attribute,
+             :embedded_resource,
+             :tuple,
+             :field_constrained_type,
+             :union_attribute
+           ] ->
         new_load =
           if nested_load != [] do
             load ++ [{internal_name, nested_load}]
@@ -310,7 +359,15 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     end
   end
 
-  defp process_calculation_with_args(resource, calc_name, args, fields, path, {select, load, template}, config) do
+  defp process_calculation_with_args(
+         resource,
+         calc_name,
+         args,
+         fields,
+         path,
+         {select, load, template},
+         config
+       ) do
     internal_name = resolve_resource_field_name(resource, calc_name, config)
     calc = Ash.Resource.Info.calculation(resource, internal_name)
 
@@ -446,7 +503,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       unwrapped_type == Ash.Type.Union ->
         :union_attribute
 
-      Keyword.has_key?(unwrapped_constraints, :fields) && Keyword.get(unwrapped_constraints, :fields) != [] ->
+      Keyword.has_key?(unwrapped_constraints, :fields) &&
+          Keyword.get(unwrapped_constraints, :fields) != [] ->
         :field_constrained_type
 
       true ->
@@ -541,7 +599,13 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   @doc """
   Selects fields from a typed map (Ash.Type.Map/Keyword with field constraints).
   """
-  def select_typed_map_fields(constraints, requested_fields, path, config, error_type \\ "field_constrained_type") do
+  def select_typed_map_fields(
+        constraints,
+        requested_fields,
+        path,
+        config,
+        error_type \\ "field_constrained_type"
+      ) do
     field_specs = get_field_specs(constraints)
 
     if field_specs == [] do
@@ -655,7 +719,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
             end
 
           {:multi_nested, entries} ->
-            Enum.reduce(entries, {select, load, template}, fn {field_name, nested_fields}, {s, l, t} ->
+            Enum.reduce(entries, {select, load, template}, fn {field_name, nested_fields},
+                                                              {s, l, t} ->
               field_atom = resolve_field_name(field_name, config)
 
               unless Validation.field_exists?(field_specs, field_atom) do
@@ -704,14 +769,41 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       Enum.reduce(normalized_fields, {[], []}, fn field, {load_acc, template_acc} ->
         case parse_field_request(field) do
           {:simple, member_name} ->
-            process_simple_union_member(member_name, union_types, path, error_type, load_acc, template_acc, config)
+            process_simple_union_member(
+              member_name,
+              union_types,
+              path,
+              error_type,
+              load_acc,
+              template_acc,
+              config
+            )
 
           {:nested, member_name, nested_fields} ->
-            process_nested_union_member(member_name, nested_fields, union_types, path, error_type, load_acc, template_acc, config)
+            process_nested_union_member(
+              member_name,
+              nested_fields,
+              union_types,
+              path,
+              error_type,
+              load_acc,
+              template_acc,
+              config
+            )
 
           {:multi_nested, entries} ->
-            Enum.reduce(entries, {load_acc, template_acc}, fn {member_name, nested_fields}, {l_acc, t_acc} ->
-              process_nested_union_member(member_name, nested_fields, union_types, path, error_type, l_acc, t_acc, config)
+            Enum.reduce(entries, {load_acc, template_acc}, fn {member_name, nested_fields},
+                                                              {l_acc, t_acc} ->
+              process_nested_union_member(
+                member_name,
+                nested_fields,
+                union_types,
+                path,
+                error_type,
+                l_acc,
+                t_acc,
+                config
+              )
             end)
 
           {:with_args, _calc_name, _args, _fields} ->
@@ -722,7 +814,15 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     {[], load_items, template_items}
   end
 
-  defp process_simple_union_member(member_name, union_types, path, error_type, load_acc, template_acc, config) do
+  defp process_simple_union_member(
+         member_name,
+         union_types,
+         path,
+         error_type,
+         load_acc,
+         template_acc,
+         config
+       ) do
     internal_name = convert_union_member_name(member_name, config)
 
     unless Keyword.has_key?(union_types, internal_name) do
@@ -745,7 +845,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       is_atom(member_type) && Introspection.is_embedded_resource?(member_type) ->
         true
 
-      Keyword.has_key?(member_constraints, :fields) && Keyword.get(member_constraints, :fields) != [] ->
+      Keyword.has_key?(member_constraints, :fields) &&
+          Keyword.get(member_constraints, :fields) != [] ->
         true
 
       true ->
@@ -753,7 +854,16 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     end
   end
 
-  defp process_nested_union_member(member_name, nested_fields, union_types, path, error_type, load_acc, template_acc, config) do
+  defp process_nested_union_member(
+         member_name,
+         nested_fields,
+         union_types,
+         path,
+         error_type,
+         load_acc,
+         template_acc,
+         config
+       ) do
     internal_name = convert_union_member_name(member_name, config)
 
     unless Keyword.has_key?(union_types, internal_name) do
@@ -776,7 +886,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       )
 
     if nested_load != [] do
-      {load_acc ++ [{internal_name, nested_load}], template_acc ++ [{member_name, nested_template}]}
+      {load_acc ++ [{internal_name, nested_load}],
+       template_acc ++ [{member_name, nested_template}]}
     else
       {load_acc, template_acc ++ [{member_name, nested_template}]}
     end
@@ -903,7 +1014,10 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   defp atomize_nested_value(%{"args" => _} = value, _resource, _config), do: value
   defp atomize_nested_value(%{fields: _} = value, _resource, _config), do: value
   defp atomize_nested_value(%{"fields" => _} = value, _resource, _config), do: value
-  defp atomize_nested_value(%{} = value, resource, config), do: atomize_field_name(value, resource, config)
+
+  defp atomize_nested_value(%{} = value, resource, config),
+    do: atomize_field_name(value, resource, config)
+
   defp atomize_nested_value(value, _resource, _config), do: value
 
   defp get_args_and_fields(map) when is_map(map) do
@@ -959,7 +1073,11 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     {unwrapped_type, constraints} =
       case type do
         {:array, inner} ->
-          Introspection.unwrap_new_type(inner, Keyword.get(type_constraints, :items, []), field_names_callback)
+          Introspection.unwrap_new_type(
+            inner,
+            Keyword.get(type_constraints, :items, []),
+            field_names_callback
+          )
 
         t when is_atom(t) ->
           Introspection.unwrap_new_type(t, type_constraints, field_names_callback)
@@ -1048,7 +1166,9 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
 
   defp is_interop_resource?(resource, config) do
     case Map.get(config, :is_interop_resource?) do
-      fun when is_function(fun, 1) -> fun.(resource)
+      fun when is_function(fun, 1) ->
+        fun.(resource)
+
       _ ->
         resource_info_module = Map.get(config, :resource_info_module)
 
@@ -1069,7 +1189,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       _ ->
         resource_info_module = Map.get(config, :resource_info_module)
 
-        if resource_info_module && function_exported?(resource_info_module, :get_original_field_name, 2) do
+        if resource_info_module &&
+             function_exported?(resource_info_module, :get_original_field_name, 2) do
           apply(resource_info_module, :get_original_field_name, [resource, field_name])
         else
           # Default: return field as-is if atom, or convert if string

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -635,7 +635,12 @@ defmodule AshIntrospection.Rpc.Pipeline do
     end
   end
 
-  defp format_output_data(%{success: true, data: result_data} = result, formatter, request, config) do
+  defp format_output_data(
+         %{success: true, data: result_data} = result,
+         formatter,
+         request,
+         config
+       ) do
     {actual_data, metadata} =
       if is_map(result_data) and Map.has_key?(result_data, :data) and
            Map.has_key?(result_data, :metadata) do

--- a/lib/ash_introspection/rpc/result_processor.ex
+++ b/lib/ash_introspection/rpc/result_processor.ex
@@ -114,7 +114,8 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
   ## Returns
   `{type, constraints}` or `{nil, []}` if not found.
   """
-  @spec get_field_type_info(module() | nil, atom(), config()) :: {atom() | tuple() | nil, keyword()}
+  @spec get_field_type_info(module() | nil, atom(), config()) ::
+          {atom() | tuple() | nil, keyword()}
   def get_field_type_info(nil, _field_name, _config), do: {nil, []}
 
   def get_field_type_info(resource, field_name, config) when is_atom(resource) do
@@ -286,7 +287,8 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
     end
   end
 
-  defp extract_resource_value(value, _resource, _template, _config), do: normalize_primitive(value)
+  defp extract_resource_value(value, _resource, _template, _config),
+    do: normalize_primitive(value)
 
   defp extract_resource_field(data, resource, field_atom, acc, config) do
     case Map.get(data, field_atom) do
@@ -342,7 +344,10 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
         member_spec ->
           member_type = Keyword.get(member_spec, :type)
           member_constraints = Keyword.get(member_spec, :constraints, [])
-          extracted = extract_value(union_value, member_type, member_constraints, member_template, config)
+
+          extracted =
+            extract_value(union_value, member_type, member_constraints, member_template, config)
+
           %{active_type => extracted}
       end
     else
@@ -350,7 +355,8 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
     end
   end
 
-  defp extract_union_value(value, _constraints, _template, _config), do: normalize_primitive(value)
+  defp extract_union_value(value, _constraints, _template, _config),
+    do: normalize_primitive(value)
 
   defp member_in_template?(template, member_name) do
     Enum.any?(template, fn
@@ -408,7 +414,9 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
           {field_type, field_constraints} =
             Introspection.get_field_spec_type(field_specs, field_atom)
 
-          extracted = extract_value(field_value, field_type, field_constraints, nested_template, config)
+          extracted =
+            extract_value(field_value, field_type, field_constraints, nested_template, config)
+
           Map.put(acc, field_atom, extracted)
 
         _ ->

--- a/lib/ash_introspection/rpc/value_formatter.ex
+++ b/lib/ash_introspection/rpc/value_formatter.ex
@@ -71,7 +71,9 @@ defmodule AshIntrospection.Rpc.ValueFormatter do
 
   def format(value, type, constraints, direction, config) do
     field_names_callback = Map.get(config, :field_names_callback, :interop_field_names)
-    {unwrapped_type, full_constraints} = Introspection.unwrap_new_type(type, constraints, field_names_callback)
+
+    {unwrapped_type, full_constraints} =
+      Introspection.unwrap_new_type(type, constraints, field_names_callback)
 
     cond do
       match?({:array, _}, type) ->

--- a/lib/ash_introspection/type_system/introspection.ex
+++ b/lib/ash_introspection/type_system/introspection.ex
@@ -537,7 +537,8 @@ defmodule AshIntrospection.TypeSystem.Introspection do
     Code.ensure_loaded?(module) && function_exported?(module, callback, 0)
   end
 
-  def has_field_names_callback?(module, callback) when is_atom(module) and is_function(callback, 1) do
+  def has_field_names_callback?(module, callback)
+      when is_atom(module) and is_function(callback, 1) do
     callback.(module)
   end
 

--- a/test/ash_introspection/codegen/action_introspection_test.exs
+++ b/test/ash_introspection/codegen/action_introspection_test.exs
@@ -206,7 +206,9 @@ defmodule AshIntrospection.Codegen.ActionIntrospectionTest do
 
     test "returns resource type for single resource return" do
       assert {:ok, :resource, Post} =
-               ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_featured))
+               ActionIntrospection.action_returns_field_selectable_type?(
+                 get_action(:get_featured)
+               )
     end
 
     test "returns array_of_resource for array of resources" do
@@ -224,7 +226,9 @@ defmodule AshIntrospection.Codegen.ActionIntrospectionTest do
 
     test "returns unconstrained_map for map without field constraints" do
       assert {:ok, :unconstrained_map, nil} =
-               ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_metadata))
+               ActionIntrospection.action_returns_field_selectable_type?(
+                 get_action(:get_metadata)
+               )
     end
 
     test "returns error for primitive return types" do

--- a/test/ash_introspection/type_system/introspection_test.exs
+++ b/test/ash_introspection/type_system/introspection_test.exs
@@ -182,9 +182,7 @@ defmodule AshIntrospection.TypeSystem.IntrospectionTest do
 
   describe "is_resource_instance_of?/1" do
     test "returns true when instance_of is a resource" do
-      assert Introspection.is_resource_instance_of?(
-               instance_of: AshIntrospection.Test.User
-             )
+      assert Introspection.is_resource_instance_of?(instance_of: AshIntrospection.Test.User)
     end
 
     test "returns false when no instance_of" do
@@ -259,7 +257,7 @@ defmodule AshIntrospection.TypeSystem.IntrospectionTest do
     end
 
     test "returns type unchanged for non-NewType" do
-      {type, constraints} = Introspection.unwrap_new_type(Ash.Type.String, [max_length: 50])
+      {type, constraints} = Introspection.unwrap_new_type(Ash.Type.String, max_length: 50)
 
       assert Ash.Type.String == type
       assert [max_length: 50] == constraints


### PR DESCRIPTION
Closes #30

## Root cause

`.formatter.exs` was missing `import_deps: [:ash, :spark]`, so the formatter
did not recognize Ash and Spark DSL macros as no-paren calls and rewrapped
their lines on every `mix format` run.

## Churn measurement

Before this PR, `mix format --check-formatted` on `main` flagged 13 files.

After adding `import_deps: [:ash, :spark]` alone (commit 1), only 12 files
still needed formatting — `import_deps` fixed exactly one of the 13
(`test/support/resources.ex`, a DSL-macro-paren issue).

**The issue's prediction was wrong.** #30 predicted `import_deps` alone would
drop the count to a single file, `field_selector.ex`. It did not. The other
11 files (`errors.ex`, `result_processor.ex`, `pipeline.ex`,
`field_selector.ex`, `value_formatter.ex`, `introspection.ex`,
`action_introspection.ex`, `validation_error_types.ex`, `error_builder.ex`,
`atomizer.ex`, and two test files) have genuine pre-existing line-length
formatting issues unrelated to DSL macros — confirmed by inspecting the
`errors.ex` diff, which matches the seven line-wrap spots already documented
in a comment on #30.

Commit 2 runs `mix format` to clean up all 12 remaining files:
13 files changed, 274 insertions(+), 71 deletions(-) total across both
commits (`git diff origin/main --stat`).

## Behavior verification

Every changed file's AST is identical before and after formatting (checked
by parsing both versions with `Code.string_to_quoted/1` and comparing with
line/column metadata stripped) — this is a whitespace-only change.

- `mix compile --force`: clean.
- `mix test`: 221 tests, 0 failures — unchanged from `main`.
- `mix format --check-formatted`: exits 0 across the whole tree.
- Formatted with Elixir 1.18.4 (Erlang/OTP 27); `mix.exs` declares
  `elixir: "~> 1.15"`, so a later run on an older toolchain could format
  differently — worth knowing if `--check-formatted` ever disagrees in CI.

## CI step

Not included. PR #42 (adds the CI workflow, with a comment deferring the
format check to this issue) is still open as of this PR. Adding
`mix format --check-formatted` to `.github/workflows/ci.yml` here would
conflict with #42's rebase. Once #42 merges, that step is a small follow-up:
add the check step and remove the deferring comment.
