### PR TITLE
fix: handle bulk error lists, Reactor step errors and Ash.Type.Vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A failing bulk action reaches the client as one error per failed field
+  ([#16](https://github.com/udin-io/ash_introspection/issues/16)).
+  `Ash.bulk_create/update/destroy` return `%Ash.BulkResult{errors: [...]}` and
+  the pipeline forwards that list. A list matched neither `is_exception` nor
+  `is_map` in `build_error_response/1`, so every per-record validation error
+  collapsed into one "An unexpected error occurred".
+- A Reactor-backed action reports the error its step produced, not the
+  wrapper ([#17](https://github.com/udin-io/ash_introspection/issues/17)).
+  `%Reactor.Error.Invalid.RunStepError{}` is itself an exception, so it matched
+  the generic Ash clause and the client got a step-execution notice naming a
+  step it has never heard of.
+- `Ash.Type.Vector` values serialize as a list of numbers
+  ([#17](https://github.com/udin-io/ash_introspection/issues/17)).
+  `%Ash.Vector{}` keeps its floats in a packed binary that `Jason` refuses to
+  encode, so selecting a vector field either crashed the encoder or put
+  `%{data: <<...>>, dimensions: n}` on the wire.
+
 ## [0.3.0] - 2026-09-09
 
 Two breaking changes to the RPC error payload. Run the codemod that ships with

--- a/lib/ash_introspection/rpc/error_builder.ex
+++ b/lib/ash_introspection/rpc/error_builder.ex
@@ -588,6 +588,17 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
           if is_list(result), do: result, else: [result]
         end)
 
+      # === REACTOR ERRORS ===
+
+      # Reactor wraps whatever a step raises or returns. The wrapper is itself an
+      # exception, so without this clause the generic Ash clause below reports
+      # the wrapper — a step-execution notice naming a step the client has never
+      # heard of — instead of the error the step actually produced.
+      %Reactor.Error.Invalid.RunStepError{error: inner_error} ->
+        inner_error
+        |> Ash.Error.to_error_class()
+        |> do_build_error_response(formatter, field_formatter_module, config)
+
       # === ASH FRAMEWORK ERRORS ===
 
       error when is_exception(error) or is_map(error) ->

--- a/lib/ash_introspection/rpc/error_builder.ex
+++ b/lib/ash_introspection/rpc/error_builder.ex
@@ -576,6 +576,18 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
           }
         }
 
+      # === LIST OF ERRORS ===
+
+      # `Ash.bulk_create/update/destroy` return `%Ash.BulkResult{errors: [...]}`
+      # and the pipeline forwards that list verbatim. A list is neither an
+      # exception nor a map, so without this clause every per-record error
+      # collapsed into the `other ->` catch-all's single opaque message.
+      errors when is_list(errors) ->
+        Enum.flat_map(errors, fn error ->
+          result = do_build_error_response(error, formatter, field_formatter_module, config)
+          if is_list(result), do: result, else: [result]
+        end)
+
       # === ASH FRAMEWORK ERRORS ===
 
       error when is_exception(error) or is_map(error) ->

--- a/lib/ash_introspection/rpc/value_formatter.ex
+++ b/lib/ash_introspection/rpc/value_formatter.ex
@@ -105,6 +105,9 @@ defmodule AshIntrospection.Rpc.ValueFormatter do
       unwrapped_type == Ash.Type.Union ->
         format_union(value, full_constraints, direction, config)
 
+      unwrapped_type == Ash.Type.Vector ->
+        format_vector(value)
+
       is_custom_type_with_map_storage?(unwrapped_type) && is_map(value) && not is_struct(value) ->
         format_map_keys_only(value, direction, config)
 
@@ -188,6 +191,25 @@ defmodule AshIntrospection.Rpc.ValueFormatter do
   end
 
   defp format_map_keys_only(value, _direction, _config), do: value
+
+  # ---------------------------------------------------------------------------
+  # Vector Handler
+  # ---------------------------------------------------------------------------
+
+  # `%Ash.Vector{}` keeps its floats in a packed binary
+  # (`deps/ash/lib/ash/vector.ex`), which `Jason` refuses to encode, so the wire
+  # format has to be a plain list of numbers. `ResultProcessor.normalize_primitive/1`
+  # has already run `Map.from_struct/1` by the time formatting happens, hence the
+  # second clause; `Ash.Vector.from_binary/1` recovers the dimensions from the
+  # binary's header. Inbound values arrive as lists and fall through the third
+  # clause untouched, since `Ash.Type.Vector.cast_input/2` accepts a list.
+  defp format_vector(%Ash.Vector{} = vector), do: Ash.Vector.to_list(vector)
+
+  defp format_vector(%{data: data}) when is_binary(data) do
+    data |> Ash.Vector.from_binary() |> Ash.Vector.to_list()
+  end
+
+  defp format_vector(other), do: other
 
   # ---------------------------------------------------------------------------
   # Resource Handler

--- a/test/ash_introspection/rpc/error_builder_bulk_errors_test.exs
+++ b/test/ash_introspection/rpc/error_builder_bulk_errors_test.exs
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ErrorBuilderBulkErrorsTest do
+  @moduledoc """
+  Pins the error payload a client receives when a bulk action fails.
+
+  `execute_update_action/3` and `execute_destroy_action/3` run through
+  `Ash.bulk_update/4` and `Ash.bulk_destroy/4`, whose `%Ash.BulkResult{}`
+  carries `errors:` as a LIST. A list is neither an exception nor a map, so it
+  missed every clause in `build_error_response/1` and landed on the `other ->`
+  catch-all: every per-record validation error collapsed into one
+  "An unexpected error occurred" and the client learned nothing about which
+  field was wrong.
+
+  These tests drive a real `Ash.bulk_update` through the pipeline and assert
+  each per-record error survives as its own response.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.ErrorBuilder
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.Account
+  alias AshIntrospection.Test.RpcDomain
+
+  setup do
+    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
+
+    suffix = System.unique_integer([:positive])
+
+    account =
+      Account
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Bulk-#{suffix}",
+        email: "bulk-#{suffix}@example.com",
+        active: true
+      })
+      |> Ash.create!()
+
+    %{account: account}
+  end
+
+  describe "a failing bulk update" do
+    test "reaches the client as one error per failed field", %{account: account} do
+      assert {:error, errors} = update(account.id, %{name: nil, email: nil})
+      assert is_list(errors)
+
+      responses = ErrorBuilder.build_error_response(errors)
+
+      assert is_list(responses)
+      assert length(responses) == 2
+      assert Enum.all?(responses, &(&1.type == "required"))
+      assert Enum.sort(Enum.flat_map(responses, & &1.fields)) == ["email", "name"]
+    end
+
+    test "never collapses into the unknown_error catch-all", %{account: account} do
+      assert {:error, errors} = update(account.id, %{name: nil, email: nil})
+
+      responses = ErrorBuilder.build_error_response(errors)
+
+      refute Enum.any?(responses, &(&1.type == "unknown_error"))
+      refute Enum.any?(responses, &(&1.message == "An unexpected error occurred"))
+    end
+  end
+
+  describe "a list of errors" do
+    test "flattens the sub-errors of each element" do
+      errors = [
+        Ash.Error.to_error_class(Ash.Error.Changes.Required.exception(field: :title)),
+        Ash.Error.to_error_class(Ash.Error.Query.NotFound.exception())
+      ]
+
+      responses = ErrorBuilder.build_error_response(errors)
+
+      assert length(responses) == 2
+      assert Enum.map(responses, & &1.type) |> Enum.sort() == ["not_found", "required"]
+    end
+
+    test "an empty list produces no errors" do
+      assert ErrorBuilder.build_error_response([]) == []
+    end
+  end
+
+  defp update(id, input) do
+    Pipeline.execute_ash_action(
+      Request.new(%{
+        domain: RpcDomain,
+        resource: Account,
+        action: Ash.Resource.Info.action(Account, :update),
+        rpc_action: %{identities: [:_primary_key]},
+        input: input,
+        context: %{},
+        select: [:id, :name, :email],
+        load: [],
+        extraction_template: [:id, :name, :email],
+        identity: id
+      })
+    )
+  end
+end

--- a/test/ash_introspection/rpc/error_builder_reactor_test.exs
+++ b/test/ash_introspection/rpc/error_builder_reactor_test.exs
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ErrorBuilderReactorTest do
+  @moduledoc """
+  Pins the error payload a client receives from a Reactor-backed action.
+
+  Reactor wraps whatever a step raises or returns in
+  `%Reactor.Error.Invalid.RunStepError{error: inner}`. The wrapper is an
+  exception, so `build_error_response/1` matched it on the generic Ash clause
+  and reported the wrapper's own type and message — a step-execution notice
+  naming a step the client has never heard of — instead of the validation error
+  the step actually produced.
+
+  `reactor` is a non-optional dependency of `ash` (`mix.lock`: `ash 3.33.1`
+  requires `reactor ~> 1.0`), so the struct is always present and matching it
+  at compile time costs nothing.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.ErrorBuilder
+
+  describe "a Reactor step failure" do
+    test "reports the inner Ash error, not the wrapper" do
+      response =
+        "email is not a valid address"
+        |> invalid_changes()
+        |> run_step_error()
+        |> ErrorBuilder.build_error_response()
+
+      assert [error] = response
+      assert error.type == "invalid_changes"
+      assert error.message =~ "email is not a valid address"
+    end
+
+    test "reports the inner error when it already arrives as an error class" do
+      response =
+        "email is not a valid address"
+        |> invalid_changes()
+        |> Ash.Error.to_error_class()
+        |> run_step_error()
+        |> ErrorBuilder.build_error_response()
+
+      assert [error] = response
+      assert error.type == "invalid_changes"
+      assert error.message =~ "email is not a valid address"
+    end
+
+    test "keeps every sub-error of an inner error that carries several" do
+      inner =
+        Ash.Error.to_error_class([
+          Ash.Error.Changes.Required.exception(field: :name),
+          Ash.Error.Changes.Required.exception(field: :email)
+        ])
+
+      response = inner |> run_step_error() |> ErrorBuilder.build_error_response()
+
+      assert length(response) == 2
+      assert Enum.sort(Enum.flat_map(response, & &1.fields)) == ["email", "name"]
+    end
+
+    @tag capture_log: true
+    test "falls back to a generic error when the inner error is not an Ash error" do
+      response =
+        RuntimeError.exception("boom")
+        |> run_step_error()
+        |> ErrorBuilder.build_error_response()
+
+      assert [error] = response
+      assert error.type == "unknown_error"
+      refute error.message =~ "Run Step Error"
+    end
+  end
+
+  defp invalid_changes(message) do
+    Ash.Error.Changes.InvalidChanges.exception(message: message)
+  end
+
+  defp run_step_error(inner) do
+    Reactor.Error.Invalid.RunStepError.exception(
+      error: inner,
+      step: %Reactor.Step{name: :validate_email}
+    )
+  end
+end

--- a/test/ash_introspection/rpc/value_formatter_vector_test.exs
+++ b/test/ash_introspection/rpc/value_formatter_vector_test.exs
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.ValueFormatterVectorTest do
+  @moduledoc """
+  Pins what a client receives for an `Ash.Type.Vector` attribute.
+
+  `%Ash.Vector{}` keeps its floats in a packed binary — `<<3, 0, 0, 0, 63,
+  128, ...>>` — which `Jason` refuses to encode. `ValueFormatter` had no clause
+  for the type, so the vector reached stage 4 as the post-`Map.from_struct`
+  shape `%{data: <<...>>, dimensions: 3}` and either crashed the encoder or put
+  a raw binary on the wire in place of the numbers.
+
+  These tests drive a real vector attribute through the pipeline and assert the
+  client gets a list of numbers that survives `Jason.encode!/1`.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Rpc.ValueFormatter
+  alias AshIntrospection.Test.Account
+  alias AshIntrospection.Test.RpcDomain
+
+  @embedding [0.5, -1.5, 2.25]
+
+  setup do
+    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
+
+    suffix = System.unique_integer([:positive])
+
+    account =
+      Account
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Vector-#{suffix}",
+        email: "vector-#{suffix}@example.com",
+        embedding: @embedding
+      })
+      |> Ash.create!()
+
+    %{account: account}
+  end
+
+  describe "a vector attribute on the output path" do
+    test "reaches the client as a list of numbers", %{account: account} do
+      response = read(account.email)
+
+      assert response["embedding"] == @embedding
+      assert Enum.all?(response["embedding"], &is_number/1)
+    end
+
+    test "survives JSON encoding", %{account: account} do
+      json = account.email |> read() |> Jason.encode!()
+
+      assert json =~ "0.5"
+      assert json =~ "2.25"
+    end
+
+    test "a null vector stays null" do
+      suffix = System.unique_integer([:positive])
+
+      account =
+        Account
+        |> Ash.Changeset.for_create(:create, %{
+          name: "NoVector-#{suffix}",
+          email: "novector-#{suffix}@example.com"
+        })
+        |> Ash.create!()
+
+      assert read(account.email)["embedding"] == nil
+    end
+  end
+
+  describe "a vector reaching the formatter unnormalized" do
+    test "an %Ash.Vector{} struct becomes a list of numbers" do
+      assert {:ok, vector} = Ash.Vector.new(@embedding)
+
+      assert ValueFormatter.format(vector, Ash.Type.Vector, [], :output) == @embedding
+    end
+
+    test "a list on the input path is left alone" do
+      assert ValueFormatter.format(@embedding, Ash.Type.Vector, [], :input) == @embedding
+    end
+  end
+
+  defp read(email) do
+    request =
+      Request.new(%{
+        domain: RpcDomain,
+        resource: Account,
+        action: Ash.Resource.Info.action(Account, :get_account),
+        rpc_action: %{},
+        input: %{},
+        context: %{},
+        select: [:id, :name, :email, :embedding],
+        load: [],
+        extraction_template: [:id, :name, :email, :embedding],
+        get_by: %{email: email}
+      })
+
+    assert {:ok, record} = Pipeline.execute_ash_action(request)
+    assert {:ok, filtered} = Pipeline.process_result(record, request)
+
+    response = Pipeline.format_output_with_request(%{success: true, data: filtered}, request)
+
+    assert response["success"] == true
+    response["data"]
+  end
+end

--- a/test/support/rpc_resources.ex
+++ b/test/support/rpc_resources.ex
@@ -22,6 +22,10 @@ defmodule AshIntrospection.Test.Account do
   `:active` is a boolean identity key (`:unique_name_active`) because an
   identity value of `false` is the case a `Map.get/2 || Map.get/2` lookup
   silently turns into `nil`, resolving the filter against the wrong record.
+
+  `:embedding` is an `Ash.Type.Vector`, whose `%Ash.Vector{}` keeps its floats
+  in a packed binary that JSON cannot encode. It is here so the output path can
+  be driven end to end against a real vector attribute.
   """
   use Ash.Resource,
     domain: AshIntrospection.Test.RpcDomain,
@@ -32,6 +36,7 @@ defmodule AshIntrospection.Test.Account do
     attribute(:name, :string, allow_nil?: false, public?: true)
     attribute(:email, :string, allow_nil?: false, public?: true)
     attribute(:active, :boolean, public?: true)
+    attribute(:embedding, :vector, public?: true, constraints: [dimensions: 3])
   end
 
   identities do


### PR DESCRIPTION
Three missing clauses in the error and value formatting layer. They ship
together because #16 and #17 both edit `error_builder.ex`, so splitting them
would only manufacture a conflict.

Closes #16
Closes #17

## What was broken

| Shape | Where it landed before | What the client saw |
| --- | --- | --- |
| `%Ash.BulkResult{errors: [...]}` | `other ->` catch-all | one "An unexpected error occurred" for every failed field |
| `%Reactor.Error.Invalid.RunStepError{}` | generic Ash clause | a step-execution notice naming a step the client never heard of |
| `%Ash.Vector{}` | no clause at all | `Jason.EncodeError: invalid byte 0xBF`, or `%{data: <<...>>, dimensions: 3}` on the wire |

## The fixes

- **`error_builder.ex` — a list of errors.** `Ash.bulk_create/update/destroy`
  return `%Ash.BulkResult{errors: [...]}`, and `execute_update_action/3` and
  `execute_destroy_action/3` forward that list verbatim. A list is neither an
  exception nor a map, so it missed every clause. The new
  `errors when is_list(errors)` clause flat-maps each element back through
  `do_build_error_response/4`. Ported from upstream `a1bbe60`.
- **`error_builder.ex` — Reactor step errors.** Reactor wraps whatever a step
  raises or returns. The wrapper is itself an exception, so it matched the
  generic Ash clause. The new clause unwraps `%RunStepError{error: inner}`
  through `Ash.Error.to_error_class/1` and recurses. Ported from upstream
  `1e767a3`.
- **`value_formatter.ex` — `Ash.Type.Vector`.** `%Ash.Vector{}` keeps its
  floats in a packed binary. `format_vector/1` has three clauses: the struct,
  the post-`Map.from_struct` `%{data: binary}` shape that the CRUD path
  actually produces, and passthrough for the list an input value arrives as.
  Ported from upstream `8ebc8cc`.

## Dependency check

Both types are reachable with no new dependency:

- `reactor 1.0.6` is a **non-optional** dependency of `ash 3.33.1`
  (`mix.lock`), so `%Reactor.Error.Invalid.RunStepError{}` matches at compile
  time with no coupling risk. No defensive struct-name match was needed.
- `Ash.Vector` and `Ash.Type.Vector` ship in `ash` itself
  (`deps/ash/lib/ash/vector.ex`, `deps/ash/lib/ash/type/vector.ex`). The type
  needs no particular data layer — the ETS test layer stores it fine — so the
  vector test drives a real `:vector` attribute end to end.

## Test plan

`main` was at 255 tests, 0 failures. This branch is at **268 tests, 0
failures**. All three fixes were driven test-first, and each test was watched
failing against the old code before the clause was added.

- `test/ash_introspection/rpc/error_builder_bulk_errors_test.exs` (4 tests) —
  drives a **real `Ash.bulk_update`** through `Pipeline.execute_ash_action/2`
  against `AshIntrospection.Test.Account` with `%{name: nil, email: nil}`. The
  pipeline returns `{:error, [%Ash.Error.Invalid{errors: [Required, Required]}]}`,
  and the test asserts two distinct `"required"` responses carrying `["email",
  "name"]` — plus an explicit `refute` on the `unknown_error` catch-all.
- `test/ash_introspection/rpc/error_builder_reactor_test.exs` (4 tests) — a bare
  inner error, an inner error already wrapped as an error class, an inner error
  carrying several sub-errors, and a non-Ash inner error falling back to
  `unknown_error`.
- `test/ash_introspection/rpc/value_formatter_vector_test.exs` (5 tests) — a real
  `:vector` attribute read back through stages 2, 3 and 4, asserting the value is
  `[0.5, -1.5, 2.25]`, that the payload survives `Jason.encode!/1`, that a null
  vector stays null, and that an unnormalized `%Ash.Vector{}` and an inbound list
  both format correctly through `ValueFormatter.format/5`.

Full CI gate run locally, all five steps green: `mix format --check-formatted`,
`mix compile --warnings-as-errors`, `mix test`, `mix hex.audit`,
`mix deps.audit`.

## Note for reviewers

`test/support/rpc_resources.ex` gains one attribute —
`attribute(:embedding, :vector, public?: true, constraints: [dimensions: 3])`
on `AshIntrospection.Test.Account` — so the vector path can be driven against a
real resource rather than a hand-built struct. Every error payload added here
uses `type:`, per 0.3.0.
