### PR TITLE
fix: guard function_exported?/3 checks on consumer modules with Code.ensure_loaded?/1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,11 +94,22 @@ between a warm and a cold VM. A test only reaches the branch after calling
 for a module the VM has not loaded yet, so a consumer's domain or type that has
 not been touched in the current process silently takes the fallback path.
 
-**What we do.** Every check against a module we did not write is guarded.
-`lib/ash_introspection/type_system/introspection.ex` does it correctly at lines
-276, 352, 464, 507 and 537. Issue #49 tracks one site that does not
-(`Errors.get_show_raised_errors?/2`); grep for bare `function_exported?/3`
-before adding another.
+**What we do.** Every check against a module we did not write is guarded. #49
+swept the library and guarded nine sites across `Rpc.Errors`,
+`Rpc.ResultProcessor`, `Rpc.FieldProcessing.Atomizer`,
+`Rpc.FieldProcessing.FieldSelector`, `TypeSystem.Introspection` and
+`Codegen.TypeDiscovery`. Grep for bare `function_exported?/3` before adding
+another; `grep -rn 'function_exported?' lib | grep -v 'Code.ensure_loaded?'`
+should print only continuation lines of guarded expressions.
+
+**Testing it.** A test that calls `Code.ensure_loaded!/1` to reach the branch
+proves nothing — it loads the module and hides the bug. Unload the module
+first (`:code.purge/1`, `:code.delete/1`, `:code.purge/1`), assert
+`refute :erlang.module_loaded(module)`, then call the public function. The
+module must be defined in `test/support/*.ex` and not inline in the `.exs`:
+only a module with a `.beam` file on disk can be loaded back. Unloading is
+global to the VM, so such a file is `async: false`. See
+`test/ash_introspection/lazy_module_loading_test.exs`.
 
 ### No stdlib `JSON`: `mix.exs` declares `elixir: "~> 1.15"`
 
@@ -170,7 +181,7 @@ at the top of every `.ex`, `.exs` and `.md` file. Markdown uses an HTML comment.
 
 ### The consumer is not covered by anything here
 
-**Symptom.** A change passes 255 tests here and breaks
+**Symptom.** A change passes 274 tests here and breaks
 `ash_kotlin_multiplatform`.
 
 **Why.** `ash_kotlin_multiplatform` calls `AshIntrospection` at 35 sites across
@@ -197,7 +208,7 @@ mix hex.audit
 mix deps.audit
 ```
 
-`main` is at **255 tests, 0 failures**. A pull request that changes that number
+`main` is at **274 tests, 0 failures**. A pull request that changes that number
 downward, or that leaves a compiler warning, is not finished. Never suppress a
 warning — fix the cause.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,17 @@ which come first. Numbers in parentheses are GitHub issues on
 
 ## Shipped
 
+### Unreleased
+
+- **Guard every consumer-module callback check with `Code.ensure_loaded?/1`**
+  (#49). `function_exported?/3` answers `false` for a module the VM has not
+  loaded, and Elixir loads lazily, so a domain, resource or type nothing had
+  touched silently lost its configuration — a cold VM behaved differently
+  from a warm one. Nine call sites across `Rpc.Errors`, `Rpc.ResultProcessor`,
+  `Rpc.FieldProcessing.Atomizer`, `Rpc.FieldProcessing.FieldSelector`,
+  `TypeSystem.Introspection` and `Codegen.TypeDiscovery` are now guarded. One
+  remains, in `Rpc.Pipeline`; #44 owns that file.
+
 ### 0.3.0 — 2026-09-09
 
 A security release, then the breaking change it forced. Every entry below is a
@@ -54,8 +65,7 @@ dozen other items.
    with a precomputed Spark manifest in `ash` 3.32.3. This repo still calls
    `Ash.Resource.Info` at ~66 sites, which is why upstream's type-discovery
    fixes do not port cleanly. Blocks #19, #20, #21, #22, #24, #25, #26 and more.
-2. **Correctness fixes that need no manifest**: #49 (bare
-   `function_exported?/3` gives a false negative on a cold VM), #40 (second
+2. **Correctness fixes that need no manifest**: #40 (second
    `rescue` in `process_single_error` has no `catch` clause), #44 (reads
    silently ignore the `identity` param), #35 (tuple nested selection keys its
    template from the raw wire name), #16 (a list of errors in

--- a/lib/ash_introspection/codegen/type_discovery.ex
+++ b/lib/ash_introspection/codegen/type_discovery.ex
@@ -547,7 +547,8 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
     instance_of = Keyword.get(constraints, :instance_of)
 
     field_name_mappings =
-      if instance_of && function_exported?(instance_of, field_names_callback, 0) do
+      if instance_of && Code.ensure_loaded?(instance_of) &&
+           function_exported?(instance_of, field_names_callback, 0) do
         apply(instance_of, field_names_callback, [])
       else
         nil

--- a/lib/ash_introspection/rpc/errors.ex
+++ b/lib/ash_introspection/rpc/errors.ex
@@ -123,7 +123,8 @@ defmodule AshIntrospection.Rpc.Errors do
 
     # Apply resource-level error handler if configured
     transformed_error =
-      if resource && function_exported?(resource, :handle_rpc_error, 2) do
+      if resource && Code.ensure_loaded?(resource) &&
+           function_exported?(resource, :handle_rpc_error, 2) do
         apply_error_handler(
           {resource, :handle_rpc_error, []},
           transformed_error,
@@ -199,7 +200,8 @@ defmodule AshIntrospection.Rpc.Errors do
     rpc_dsl_section = Map.get(config, :rpc_dsl_section, :typescript_rpc)
 
     # Check if domain has RPC configuration with error handler
-    with true <- function_exported?(domain, :spark_dsl_config, 0),
+    with true <- Code.ensure_loaded?(domain),
+         true <- function_exported?(domain, :spark_dsl_config, 0),
          {:ok, handler} <-
            Spark.Dsl.Extension.fetch_opt(domain, [rpc_dsl_section], :error_handler) do
       case handler do
@@ -218,7 +220,8 @@ defmodule AshIntrospection.Rpc.Errors do
   defp get_show_raised_errors?(domain, config) do
     rpc_dsl_section = Map.get(config, :rpc_dsl_section, :typescript_rpc)
 
-    with true <- function_exported?(domain, :spark_dsl_config, 0),
+    with true <- Code.ensure_loaded?(domain),
+         true <- function_exported?(domain, :spark_dsl_config, 0),
          {:ok, show_raised_errors?} <-
            Spark.Dsl.Extension.fetch_opt(domain, [rpc_dsl_section], :show_raised_errors?) do
       show_raised_errors?

--- a/lib/ash_introspection/rpc/field_processing/atomizer.ex
+++ b/lib/ash_introspection/rpc/field_processing/atomizer.ex
@@ -92,7 +92,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Atomizer do
       # Use resource info module if provided
       resource_info_module && resource ->
         is_resource? =
-          if function_exported?(resource_info_module, :interop_resource?, 1) do
+          if Code.ensure_loaded?(resource_info_module) &&
+               function_exported?(resource_info_module, :interop_resource?, 1) do
             apply(resource_info_module, :interop_resource?, [resource])
           else
             false
@@ -151,7 +152,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.Atomizer do
       # Use resource info module if provided
       resource_info_module && resource ->
         is_resource? =
-          if function_exported?(resource_info_module, :interop_resource?, 1) do
+          if Code.ensure_loaded?(resource_info_module) &&
+               function_exported?(resource_info_module, :interop_resource?, 1) do
             apply(resource_info_module, :interop_resource?, [resource])
           else
             false

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -1172,7 +1172,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       _ ->
         resource_info_module = Map.get(config, :resource_info_module)
 
-        if resource_info_module && function_exported?(resource_info_module, :interop_resource?, 1) do
+        if resource_info_module && Code.ensure_loaded?(resource_info_module) &&
+             function_exported?(resource_info_module, :interop_resource?, 1) do
           apply(resource_info_module, :interop_resource?, [resource])
         else
           # Default: check if it's an Ash resource
@@ -1189,7 +1190,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       _ ->
         resource_info_module = Map.get(config, :resource_info_module)
 
-        if resource_info_module &&
+        if resource_info_module && Code.ensure_loaded?(resource_info_module) &&
              function_exported?(resource_info_module, :get_original_field_name, 2) do
           apply(resource_info_module, :get_original_field_name, [resource, field_name])
         else

--- a/lib/ash_introspection/rpc/result_processor.ex
+++ b/lib/ash_introspection/rpc/result_processor.ex
@@ -736,7 +736,8 @@ defmodule AshIntrospection.Rpc.ResultProcessor do
       is_struct(data) && Ash.Resource.Info.resource?(data.__struct__) ->
         {data.__struct__, []}
 
-      is_struct(data) && function_exported?(data.__struct__, field_names_callback, 0) ->
+      is_struct(data) && Code.ensure_loaded?(data.__struct__) &&
+          function_exported?(data.__struct__, field_names_callback, 0) ->
         {Ash.Type.Struct, [instance_of: data.__struct__]}
 
       match?(%Ash.Union{}, data) ->

--- a/lib/ash_introspection/type_system/introspection.ex
+++ b/lib/ash_introspection/type_system/introspection.ex
@@ -243,7 +243,7 @@ defmodule AshIntrospection.TypeSystem.Introspection do
   # Check if a type has the field names callback
   # Supports both atom callback names and function references
   defp check_field_names_callback(type, callback) when is_atom(callback) do
-    function_exported?(type, callback, 0)
+    Code.ensure_loaded?(type) && function_exported?(type, callback, 0)
   end
 
   defp check_field_names_callback(type, callback) when is_function(callback, 1) do
@@ -560,7 +560,7 @@ defmodule AshIntrospection.TypeSystem.Introspection do
 
   def get_field_names_map(module, callback) when is_atom(module) and is_atom(callback) do
     cond do
-      function_exported?(module, callback, 0) ->
+      Code.ensure_loaded?(module) && function_exported?(module, callback, 0) ->
         apply(module, callback, []) |> Map.new()
 
       has_interop_field_names?(module) ->

--- a/test/ash_introspection/lazy_module_loading_test.exs
+++ b/test/ash_introspection/lazy_module_loading_test.exs
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.LazyModuleLoadingTest do
+  @moduledoc """
+  The sweep #49 asked for, beyond the `Errors` site the issue named.
+
+  Every callback this library reads off a module the consumer supplied — a
+  type's field-names callback, a struct's `interop_field_names/0`, a
+  `resource_info_module` handed in through config — was gated on
+  `function_exported?/3` alone. Elixir loads modules lazily, so each of those
+  answered `false` on a cold VM and the caller silently got the fallback.
+
+  Each test unloads the module first and never calls `Code.ensure_loaded!/1`,
+  which would load it and hide the bug. `async: false` because unloading a
+  module is global to the VM.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.FieldProcessing.Atomizer
+  alias AshIntrospection.Rpc.ResultProcessor
+  alias AshIntrospection.Test.Account
+  alias AshIntrospection.Test.LazyLoadedFieldNames
+  alias AshIntrospection.Test.LazyLoadedResourceInfo
+  alias AshIntrospection.Test.LazyLoadedStruct
+  alias AshIntrospection.TypeSystem.Introspection
+
+  describe "a type the VM has not loaded" do
+    test "still yields its field names map" do
+      unload!(LazyLoadedFieldNames)
+
+      assert Introspection.get_field_names_map(LazyLoadedFieldNames, :typescript_field_names) ==
+               %{is_active?: "isActive"}
+    end
+  end
+
+  describe "a struct whose module the VM has not loaded" do
+    test "is still recognised as a typed struct" do
+      # Built before the unload: a struct literal is expanded at compile time,
+      # so holding the value never loads the module it names.
+      data = %LazyLoadedStruct{name: "Alice"}
+
+      unload!(LazyLoadedStruct)
+
+      assert ResultProcessor.determine_data_type(data, nil, %{}) ==
+               {Ash.Type.Struct, [instance_of: LazyLoadedStruct]}
+    end
+  end
+
+  describe "a resource_info_module the VM has not loaded" do
+    test "still maps a client field name back to its internal name" do
+      unload!(LazyLoadedResourceInfo)
+
+      assert Atomizer.atomize_requested_fields(["givenName"], Account, %{
+               resource_info_module: LazyLoadedResourceInfo
+             }) == [:given_name]
+    end
+  end
+
+  # `:code.delete/1` moves the current version to old; the purges drop the old
+  # copy either side of it, so `:erlang.module_loaded/1` answers false and the
+  # next call has to load the module from disk to see anything on it.
+  defp unload!(module) do
+    :code.purge(module)
+    :code.delete(module)
+    :code.purge(module)
+
+    refute :erlang.module_loaded(module),
+           "#{inspect(module)} is still loaded; the test would not reach the branch it covers"
+
+    on_exit(fn -> Code.ensure_loaded(module) end)
+  end
+end

--- a/test/ash_introspection/rpc/error_type_key_test.exs
+++ b/test/ash_introspection/rpc/error_type_key_test.exs
@@ -57,10 +57,6 @@ defmodule AshIntrospection.Rpc.ErrorTypeKeyTest do
 
   describe "a domain with show_raised_errors? set" do
     test "names the exception's class under type" do
-      # `Errors` gates the branch on `function_exported?/3`, which answers false
-      # for a module the VM has not loaded yet.
-      Code.ensure_loaded!(RaisingErrorsDomain)
-
       [error] =
         Errors.to_errors(
           UnhandledError.exception(message: "shown to the client"),

--- a/test/ash_introspection/rpc/errors_lazy_module_loading_test.exs
+++ b/test/ash_introspection/rpc/errors_lazy_module_loading_test.exs
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.LazyLoadingError do
+  @moduledoc false
+  defexception [:message, :path]
+end
+
+defmodule AshIntrospection.Rpc.ErrorsLazyModuleLoadingTest do
+  @moduledoc """
+  Configuration a consumer sets must be honoured on a cold VM.
+
+  `Errors` reads `show_raised_errors?`, `error_handler` and `handle_rpc_error/2`
+  off modules the caller supplies, and gated each read on `function_exported?/3`
+  alone. Elixir loads modules lazily, so that answers `false` for a domain or
+  resource nothing in the current process has touched: the configuration was
+  silently ignored, and the same call returned different errors on a warm VM
+  than on a cold one (#49).
+
+  Every test here unloads the module first and never calls
+  `Code.ensure_loaded!/1` — doing so would load the module and hide the bug.
+  The file is `async: false` because unloading a module is global to the VM.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.Errors
+  alias AshIntrospection.Test.LazyLoadedErrorResource
+  alias AshIntrospection.Test.LazyLoadedHandlerDomain
+  alias AshIntrospection.Test.LazyLoadedRaisingDomain
+  alias AshIntrospection.Test.LazyLoadingError
+
+  @config %{rpc_dsl_section: :typescript_rpc}
+
+  describe "a domain the VM has not loaded" do
+    test "still has its show_raised_errors? honoured" do
+      unload!(LazyLoadedRaisingDomain)
+
+      [error] =
+        Errors.to_errors(
+          LazyLoadingError.exception(message: "shown to the client"),
+          LazyLoadedRaisingDomain,
+          nil,
+          nil,
+          %{},
+          @config
+        )
+
+      assert error.message =~ "shown to the client"
+    end
+
+    test "still has its error_handler applied" do
+      unload!(LazyLoadedHandlerDomain)
+
+      [error] =
+        Errors.to_errors(
+          LazyLoadingError.exception(message: "hidden from the client"),
+          LazyLoadedHandlerDomain,
+          nil,
+          nil,
+          %{},
+          @config
+        )
+
+      assert error.message == "handled by the domain"
+    end
+  end
+
+  describe "a resource the VM has not loaded" do
+    test "still has its handle_rpc_error/2 applied" do
+      unload!(LazyLoadedErrorResource)
+
+      [error] =
+        Errors.to_errors(
+          LazyLoadingError.exception(message: "hidden from the client"),
+          nil,
+          LazyLoadedErrorResource,
+          nil,
+          %{},
+          @config
+        )
+
+      assert error.message == "handled by the resource"
+    end
+  end
+
+  # `:code.delete/1` moves the current version to old; the purges drop the old
+  # copy either side of it, so `:erlang.module_loaded/1` answers false and the
+  # next call has to load the module from disk to see anything on it.
+  defp unload!(module) do
+    :code.purge(module)
+    :code.delete(module)
+    :code.purge(module)
+
+    refute :erlang.module_loaded(module),
+           "#{inspect(module)} is still loaded; the test would not reach the branch it covers"
+
+    on_exit(fn -> Code.ensure_loaded(module) end)
+  end
+end

--- a/test/support/rpc_dsl.ex
+++ b/test/support/rpc_dsl.ex
@@ -102,3 +102,26 @@ defmodule AshIntrospection.Test.LazyLoadedFieldNames do
 
   def typescript_field_names, do: %{is_active?: "isActive"}
 end
+
+defmodule AshIntrospection.Test.LazyLoadedStruct do
+  @moduledoc """
+  Stands in for a consumer's TypedStruct wrapper, for the
+  `ResultProcessor.determine_data_type/3` lazy-loading test.
+  """
+
+  defstruct [:name]
+
+  def interop_field_names, do: %{name: "name"}
+end
+
+defmodule AshIntrospection.Test.LazyLoadedResourceInfo do
+  @moduledoc """
+  Stands in for the `resource_info_module` a consumer passes in its config, for
+  the `Atomizer` lazy-loading test.
+  """
+
+  def interop_resource?(_resource), do: true
+
+  def get_original_field_name(_resource, "givenName"), do: :given_name
+  def get_original_field_name(_resource, _field_name), do: nil
+end

--- a/test/support/rpc_dsl.ex
+++ b/test/support/rpc_dsl.ex
@@ -43,3 +43,62 @@ defmodule AshIntrospection.Test.RaisingErrorsDomain do
   resources do
   end
 end
+
+defmodule AshIntrospection.Test.LazyLoadedErrorHandler do
+  @moduledoc """
+  Domain-level `error_handler` for the lazy-loading tests. Rewrites every
+  message so a test can tell the configured handler from the default one.
+  """
+
+  def handle_error(error, _context), do: %{error | message: "handled by the domain"}
+end
+
+defmodule AshIntrospection.Test.LazyLoadedRaisingDomain do
+  @moduledoc """
+  Domain used only by `AshIntrospection.Rpc.ErrorsLazyModuleLoadingTest`, which
+  unloads it from the VM. It is separate from `RaisingErrorsDomain` so that
+  unloading cannot race another test that reads the same module.
+  """
+  use Ash.Domain, extensions: [AshIntrospection.Test.RpcDsl], validate_config_inclusion?: false
+
+  typescript_rpc do
+    show_raised_errors?(true)
+  end
+
+  resources do
+  end
+end
+
+defmodule AshIntrospection.Test.LazyLoadedHandlerDomain do
+  @moduledoc """
+  Domain carrying only an `error_handler`, so a test can tell the configured
+  handler from the default one without `show_raised_errors?` also rewriting the
+  message.
+  """
+  use Ash.Domain, extensions: [AshIntrospection.Test.RpcDsl], validate_config_inclusion?: false
+
+  typescript_rpc do
+    error_handler(AshIntrospection.Test.LazyLoadedErrorHandler)
+  end
+
+  resources do
+  end
+end
+
+defmodule AshIntrospection.Test.LazyLoadedErrorResource do
+  @moduledoc """
+  Stands in for a consumer resource that defines `handle_rpc_error/2`. Not an
+  Ash resource: `Errors` reaches the callback off any module the caller passes.
+  """
+
+  def handle_rpc_error(error, _context), do: %{error | message: "handled by the resource"}
+end
+
+defmodule AshIntrospection.Test.LazyLoadedFieldNames do
+  @moduledoc """
+  Stands in for a consumer type that declares a field-names callback, for the
+  `Introspection.get_field_names_map/2` lazy-loading test.
+  """
+
+  def typescript_field_names, do: %{is_active?: "isActive"}
+end


### PR DESCRIPTION
## What this fixes

`function_exported?/3` answers `false` for a module the VM has not loaded yet,
and Elixir loads modules lazily. Every check this library made against a
consumer-supplied module — a domain, a resource, a type, a
`resource_info_module` handed in through config — therefore took the fallback
path on a cold VM. The consumer's configuration was silently ignored, and the
same call returned a different answer on a warm VM than on a cold one.

The tell the issue named: the existing `show_raised_errors?` test had to call
`Code.ensure_loaded!/1` before it could reach the branch at all. That line is
gone now.

Closes #49.

## The sweep

The issue asked for a grep across the repo. Nine sites were bare and are now
guarded with `Code.ensure_loaded?/1`, matching the style already used in
`type_system/introspection.ex` at lines 276, 464 and 537 (upstream `ba1e661`).

| Site | Module checked | Verdict |
|---|---|---|
| `rpc/errors.ex:126` | `resource`, for `handle_rpc_error/2` | guarded |
| `rpc/errors.ex:202` | `domain`, for the `error_handler` opt | guarded |
| `rpc/errors.ex:221` | `domain`, for `show_raised_errors?` — the issue's site | guarded |
| `rpc/result_processor.ex:739` | `data.__struct__` | guarded (see below) |
| `rpc/field_processing/atomizer.ex:95` | `resource_info_module` from config | guarded |
| `rpc/field_processing/atomizer.ex:154` | `resource_info_module` from config | guarded |
| `rpc/field_processing/field_selector.ex:1175` | `resource_info_module` from config | guarded |
| `rpc/field_processing/field_selector.ex:1193` | `resource_info_module` from config | guarded |
| `codegen/type_discovery.ex:550` | `instance_of` from a type's constraints | guarded |
| `type_system/introspection.ex:246` | a NewType | guarded (see below) |
| `type_system/introspection.ex:563` | a consumer type, in `get_field_names_map/2` | guarded |
| `rpc/pipeline.ex:748` | a typed-struct module | **left alone — #44 owns that file** |

Two of those were already safe, and are guarded anyway so the behaviour no
longer rests on an accident:

- `result_processor.ex:739` sits in a `cond` whose previous clause calls
  `Ash.Resource.Info.resource?(data.__struct__)`, and that reaches
  `module_info/1`, which loads the module. The test for it was green before the
  guard; it stays as a pin on the behaviour in case the clauses are reordered.
- `introspection.ex:246` is only reached after
  `Ash.Type.NewType.new_type?/1` and `type.do_init/1`, both of which load the
  type.

Sites already correct and untouched: `introspection.ex` 276, 353, 464, 508,
537; `result_processor.ex` 139, 234; `value_formatter.ex` 122, 297.

## Test plan

Two new files, 6 tests, both `async: false` because unloading a module is
global to the VM:

- `test/ash_introspection/rpc/errors_lazy_module_loading_test.exs` — the three
  `Errors` sites, through `Errors.to_errors/6`.
- `test/ash_introspection/lazy_module_loading_test.exs` — the sweep:
  `Introspection.get_field_names_map/2`,
  `ResultProcessor.determine_data_type/3`,
  `Atomizer.atomize_requested_fields/3`.

Each test unloads the module with `:code.purge/1` + `:code.delete/1` +
`:code.purge/1`, asserts `refute :erlang.module_loaded(module)`, and then calls
the public function. None calls `Code.ensure_loaded!/1` — that would load the
module and hide the bug the test exists to catch. The support modules live in
`test/support/rpc_dsl.ex` rather than inline in the `.exs`, because only a
module with a `.beam` file on disk can be loaded back after a purge.

Five of the six fail against `main`:

```
1) still has its show_raised_errors? honoured   left: "Something went wrong"
2) still has its error_handler applied          left: "Something went wrong"
3) still has its handle_rpc_error/2 applied     left: "Something went wrong"
4) still yields its field names map             left: %{}
5) still maps a client field name back          left: ["givenName"]
```

The sixth (`determine_data_type/3`) passed before the change, for the reason in
the table above.

Locally, all five CI gates:

```
mix format --check-formatted   OK
mix compile --warnings-as-errors   no warnings
mix test   274 tests, 0 failures  (main: 268; also green on seeds 1, 42, 99999)
mix hex.audit   No retired packages found
mix deps.audit  No vulnerabilities found.
```

## Docs

- `docs/roadmap.md` — #49 moves out of "Next" into a new "Unreleased" heading
  under Shipped.
- `CLAUDE.md` — the existing `Code.ensure_loaded?/1` lesson pointed at #49 as
  an open site. It now states what the sweep covered, carries the grep that
  proves no bare call is left, and records how to test the branch. Test count
  updated to 274.
