### PR TITLE
fix: reject `identity` on read actions rather than dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking.** A read action carrying `identity` is rejected with
+  `identity_not_supported` instead of having the parameter dropped
+  ([#44](https://github.com/udin-io/ash_introspection/issues/44)). `identity`
+  selects a record for update and destroy; reads select one with `get_by`, the
+  same split upstream `ash_typescript` draws. A read used to build no filter at
+  all, so the caller named one record and got the whole table, or a
+  `MultipleResults` from `Ash.read_one/1`. Generated Swift clients from
+  `ash_kotlin_multiplatform` send `identity` on `get?` reads and must move
+  those calls to `get_by`.
+- **Breaking.** A `null` identity value is rejected with `invalid_identity`
+  ([#44](https://github.com/udin-io/ash_introspection/issues/44)). It used to
+  compile to `key == nil`, which Ash evaluates as unknown, so the lookup
+  matched nothing and surfaced as `NotFound`.
+
 ### Fixed
 
 - A failing bulk action reaches the client as one error per failed field

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ at the top of every `.ex`, `.exs` and `.md` file. Markdown uses an HTML comment.
 
 ### The consumer is not covered by anything here
 
-**Symptom.** A change passes 274 tests here and breaks
+**Symptom.** A change passes 281 tests here and breaks
 `ash_kotlin_multiplatform`.
 
 **Why.** `ash_kotlin_multiplatform` calls `AshIntrospection` at 35 sites across
@@ -208,7 +208,7 @@ mix hex.audit
 mix deps.audit
 ```
 
-`main` is at **274 tests, 0 failures**. A pull request that changes that number
+`main` is at **281 tests, 0 failures**. A pull request that changes that number
 downward, or that leaves a compiler warning, is not finished. Never suppress a
 warning — fix the cause.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,12 +95,20 @@ for a module the VM has not loaded yet, so a consumer's domain or type that has
 not been touched in the current process silently takes the fallback path.
 
 **What we do.** Every check against a module we did not write is guarded. #49
-swept the library and guarded nine sites across `Rpc.Errors`,
+swept the library and guarded ten sites across `Rpc.Errors`,
 `Rpc.ResultProcessor`, `Rpc.FieldProcessing.Atomizer`,
-`Rpc.FieldProcessing.FieldSelector`, `TypeSystem.Introspection` and
-`Codegen.TypeDiscovery`. Grep for bare `function_exported?/3` before adding
+`Rpc.FieldProcessing.FieldSelector`, `Rpc.Pipeline`, `TypeSystem.Introspection`
+and `Codegen.TypeDiscovery`. Grep for bare `function_exported?/3` before adding
 another; `grep -rn 'function_exported?' lib | grep -v 'Code.ensure_loaded?'`
-should print only continuation lines of guarded expressions.
+should print only comment and continuation lines of guarded expressions.
+
+**Not every guarded site is observable.** `get_field_mapping_module/3` in
+`Rpc.Pipeline` is the one that has no test. Both of its outcomes — the
+consumer's struct module, or `nil` — reach
+`ResultProcessor.get_field_type_info/3`, which answers `{nil, []}` either way,
+so the whole suite passes with the branch hard-coded to `nil` (measured
+2026-09-09, 281 tests). The guard is still right; do not delete it because
+nothing covers it, and do not write a test that cannot fail.
 
 **Testing it.** A test that calls `Code.ensure_loaded!/1` to reach the branch
 proves nothing — it loads the module and hides the bug. Unload the module

--- a/README.md
+++ b/README.md
@@ -687,6 +687,12 @@ identity: %{org_id: "org-1", user_id: "user-1"}
 identity: %{email: "user@example.com"}
 ```
 
+`identity` selects the record an update or destroy acts on. A read selects one
+with `get_by`, and a read carrying `identity` is rejected with
+`identity_not_supported` rather than having the parameter dropped. Identity
+values are equality operands: a map or list value is rejected as
+`invalid_identity`, and so is `null`.
+
 ### 6. Pagination Response Handling
 
 Handle both paginated and non-paginated responses:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,6 +13,46 @@ recorded nowhere in the repo. This page replaces ADRs; there is no `adr/`
 directory here and none should be created. A decision that no longer shapes the
 code is deleted, not archived, because git keeps the history.
 
+## 2026-09-09 — `identity` is an update/destroy key; reads reject it
+
+**Decided.** A read action carrying `identity` fails with
+`identity_not_supported` naming the action. Reads select a record with
+`get_by`. Wiring `identity` into the read path was rejected. Issue #44.
+
+**Why.** Upstream `ash_typescript` already means this. Its `identities` option
+resolves to `[]` for every action type but `:update` and `:destroy`
+(`lib/ash_typescript/rpc/codegen/helpers/config_builder.ex:63-67`), so the
+field is emitted into neither the generated config type nor the request
+payload, and no generated client can send it on a read. This library exists to
+be the shared core of that design, so the alternative — teaching reads a
+lookup key upstream does not have — was the divergence, not the rejection.
+
+It would also have needed rules upstream has never written. `identities`
+defaults to `[:_primary_key]`, and `maybe_apply_identity_filter/5` errors with
+`missing_identity` when the identity is absent but the list is not empty. Reads
+would have needed their own default of `[]`, so the symmetry with update and
+destroy was never real.
+
+Rejecting is what removes the silence the ticket was filed about. The old
+behaviour built no filter: the caller named one record and got the whole table,
+or a `MultipleResults` from `Ash.read_one/1` naming nothing it could act on.
+That is not hypothetical — `ash_kotlin_multiplatform`'s Swift generator sends
+it. `generate_get_function/3` emits `identity: id` for `get?` reads
+(`lib/ash_kotlin_multiplatform/swift/codegen.ex:581-594`), so every generated
+Swift `getX(id:)` call is broken today. Its Kotlin generator gates on the same
+empty list upstream does and never sends it.
+
+**Cost.** A generated Swift client that compiles now fails at runtime with a
+named error instead of returning the wrong record, so
+`ash_kotlin_multiplatform` has to move those reads to `get_by` before it takes
+this release. That is the point — the failure was already there and was
+silent — but it is a real break for a consumer that is not covered by any
+test here. Same release also stops accepting a null identity value: it compiled
+to `key == nil`, which Ash evaluates as unknown, and building `is_nil(key)`
+instead would let a null key match several records, since Ash identities
+default to `nils_distinct?: true` and update and destroy take
+`Ash.Query.limit(query, 1)`.
+
 ## 2026-09-09 — Unify RPC error payloads on `type`, and ship a codemod with it
 
 **Decided.** Every RPC error names its class under `type`. The `code` key is

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -50,6 +50,15 @@ with a codemod (`mix ash_introspection.upgrade`), which limits the damage to
 Elixir call sites; a generated Kotlin client that reads `error.code` is
 regenerated, not migrated, and nothing checks that it was.
 
+**Now realised, not hypothetical.** #44 found the consumer's Swift generator
+sending `identity` on read actions — `generate_get_function/3` at
+`lib/ash_kotlin_multiplatform/swift/codegen.ex:581-594` emits `identity: id`
+for every `get?` read. This library dropped that parameter without a word, so
+those calls have been returning the wrong record all along. They now fail with
+`identity_not_supported`, which is the right answer and still a break the
+consumer has to act on. Its Kotlin generator was never affected: it gates on
+the same empty `identities` list upstream does.
+
 **What we watch.** `grep -rn 'AshIntrospection' lib/` in the consumer, and the
 consumer's `mix.exs` requirement, on every release here.
 
@@ -63,13 +72,13 @@ yet and is not on the board.
 **The risk.** `lib/ash_introspection/rpc/` had **zero** test coverage until the
 week of 2026-09-09 (#18). Coverage arrived as regression tests attached to the
 seven fixes shipped in 0.3.0 — one test per fixed bug, not a suite that
-describes the pipeline. `main` is at 255 tests, and whole modules
+describes the pipeline. `main` is at 281 tests, and whole modules
 (`value_formatter.ex`, `field_extractor.ex`, `atomizer.ex`) are still exercised
 only incidentally.
 
-**Why it bites.** Every open correctness issue on the board (#16, #17, #35,
-#40, #44) touches code that has no behavioural test around it, so a fix can
-break a neighbour silently.
+**Why it bites.** Every open correctness issue on the board (#35, #40, #16)
+touches code that has no behavioural test around it, so a fix can break a
+neighbour silently.
 
 **What we watch.** `mix test` count and which modules new tests land in. CI
 runs the suite on every pull request as of #32.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,10 +21,17 @@ which come first. Numbers in parentheses are GitHub issues on
   (#49). `function_exported?/3` answers `false` for a module the VM has not
   loaded, and Elixir loads lazily, so a domain, resource or type nothing had
   touched silently lost its configuration — a cold VM behaved differently
-  from a warm one. Nine call sites across `Rpc.Errors`, `Rpc.ResultProcessor`,
+  from a warm one. Ten call sites across `Rpc.Errors`, `Rpc.ResultProcessor`,
   `Rpc.FieldProcessing.Atomizer`, `Rpc.FieldProcessing.FieldSelector`,
-  `TypeSystem.Introspection` and `Codegen.TypeDiscovery` are now guarded. One
-  remains, in `Rpc.Pipeline`; #44 owns that file.
+  `Rpc.Pipeline`, `TypeSystem.Introspection` and `Codegen.TypeDiscovery` are
+  now guarded. Nine landed in #52; the tenth, in `Rpc.Pipeline`, came with #44,
+  which owned that file at the time.
+- **Reject `identity` on read actions, and reject null identity values** (#44,
+  [PR #53](https://github.com/udin-io/ash_introspection/pull/53)). `identity`
+  selects the record an update or destroy acts on; a read selects one with
+  `get_by`, the same split upstream `ash_typescript` draws. A read carrying
+  `identity` used to build no filter at all. Breaking for the consumer's
+  generated Swift clients — see [decisions.md](decisions.md).
 
 ### 0.3.0 — 2026-09-09
 
@@ -65,10 +72,9 @@ dozen other items.
    with a precomputed Spark manifest in `ash` 3.32.3. This repo still calls
    `Ash.Resource.Info` at ~66 sites, which is why upstream's type-discovery
    fixes do not port cleanly. Blocks #19, #20, #21, #22, #24, #25, #26 and more.
-2. **Correctness fixes that need no manifest**: #40 (second
-   `rescue` in `process_single_error` has no `catch` clause), #44 (reads
-   silently ignore the `identity` param), #35 (tuple nested selection keys its
-   template from the raw wire name), #16 (a list of errors in
+2. **Correctness fixes that need no manifest**: #40 (second `rescue` in
+   `process_single_error` has no `catch` clause), #35 (tuple nested selection
+   keys its template from the raw wire name), #16 (a list of errors in
    `build_error_response/1` for bulk actions), #17 (unwrap Reactor step errors,
    serialize `Ash.Type.Vector`).
 3. **#18 — the RPC test floor.** Coverage arrives with each fix by preference,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,9 @@ which come first. Numbers in parentheses are GitHub issues on
   `Rpc.FieldProcessing.Atomizer`, `Rpc.FieldProcessing.FieldSelector`,
   `Rpc.Pipeline`, `TypeSystem.Introspection` and `Codegen.TypeDiscovery` are
   now guarded. Nine landed in #52; the tenth, in `Rpc.Pipeline`, came with #44,
-  which owned that file at the time.
+  which owned that file at the time. That tenth site has no test: both of its
+  outcomes converge on `{nil, []}` downstream, so nothing observable changes.
+  See [`CLAUDE.md`](../CLAUDE.md).
 - **Reject `identity` on read actions, and reject null identity values** (#44,
   [PR #53](https://github.com/udin-io/ash_introspection/pull/53)). `identity`
   selects the record an update or destroy acts on; a read selects one with

--- a/lib/ash_introspection/rpc/error_builder.ex
+++ b/lib/ash_introspection/rpc/error_builder.ex
@@ -513,6 +513,23 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
 
       # === IDENTITY VALIDATION ERRORS ===
 
+      {:identity_not_supported, %{action: action_name}} ->
+        %{
+          type: "identity_not_supported",
+          message:
+            "Read actions do not accept an identity. %{action} looks records up with getBy.",
+          short_message: "Identity not supported",
+          vars: %{action: to_string(action_name)},
+          path: [:identity],
+          fields: [],
+          details: %{
+            action: action_name,
+            suggestion:
+              "Drop the identity parameter. Configure `get_by` on the RPC action and send the lookup fields under getBy.",
+            hint: @stale_generated_file_hint
+          }
+        }
+
       {:invalid_identity, %{provided_keys: provided_keys, expected_keys: expected_keys}} ->
         provided_keys_str = Enum.join(provided_keys, ", ")
         expected_keys_str = Enum.join(expected_keys, ", ")

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -472,6 +472,7 @@ defmodule AshIntrospection.Rpc.Pipeline do
   defp maybe_apply_identity_filter(query, identity, identities, resource, config)
        when is_map(identity) do
     with {:ok, filter} <- build_identity_filter(resource, identity, identities),
+         :ok <- validate_non_null_identity_filter(filter, config),
          :ok <- validate_scalar_identity_filter(filter, config) do
       {:ok, Ash.Query.do_filter(query, filter)}
     end
@@ -480,6 +481,7 @@ defmodule AshIntrospection.Rpc.Pipeline do
   defp maybe_apply_identity_filter(query, identity, identities, resource, config)
        when not is_nil(identity) do
     with {:ok, filter} <- build_identity_filter(resource, identity, identities),
+         :ok <- validate_non_null_identity_filter(filter, config),
          :ok <- validate_scalar_identity_filter(filter, config) do
       {:ok, Ash.Query.do_filter(query, filter)}
     end
@@ -499,6 +501,31 @@ defmodule AshIntrospection.Rpc.Pipeline do
 
   defp maybe_apply_identity_filter(query, _identity, _identities, _resource, _config),
     do: {:ok, query}
+
+  # A `nil` identity value compiles to `key == nil`, which Ash evaluates as
+  # unknown rather than as a null check, so the lookup matched nothing and
+  # surfaced as `NotFound` — an answer that reads as "no such record" when the
+  # fault is an identity that cannot name one. Building `is_nil(key)` instead
+  # would be worse: Ash identities default to `nils_distinct?: true`
+  # (`deps/ash/lib/ash/resource/identity.ex:48`), so a null key does not
+  # identify a single record, and `execute_update_action/3` and
+  # `execute_destroy_action/3` take `Ash.Query.limit(query, 1)` — the exact
+  # widening #8 closed for map and list operands. Reject the null instead.
+  defp validate_non_null_identity_filter(filter, config) do
+    case for {key, nil} <- filter, do: key do
+      [] ->
+        :ok
+
+      keys ->
+        {:error,
+         {:invalid_identity,
+          %{
+            message:
+              "Identity values may not be null. Null value provided for: " <>
+                format_filter_keys(keys, config)
+          }}}
+    end
+  end
 
   # Identity values come from the client and are applied through the *trusted*
   # filter API (Ash.Query.do_filter/2), which reads a map or list operand as an
@@ -592,20 +619,19 @@ defmodule AshIntrospection.Rpc.Pipeline do
     end
   end
 
-  # `Map.fetch/2` rather than `Map.get/2 || Map.get/2`: a boolean identity key
+  # `Map.fetch!/2` rather than `Map.get/2 || Map.get/2`: a boolean identity key
   # valued `false` is falsy, so the `||` discarded it and the filter became
   # `key == nil`. The update or destroy then ran against a record the caller
   # never named, or against none at all.
+  #
+  # `fetch!` cannot raise here. `build_identity_filter/3` picks a named identity
+  # only when `Enum.all?(identity_info.keys, &Map.has_key?(parsed_identity, &1))`
+  # holds, so every atom key is present by the time this runs. #15 carried a
+  # string-key fallback for parity with upstream `ash_typescript`; #44 removed
+  # it because the same guard makes it unreachable there too, and dead code that
+  # looks like a safety net invites the next reader to trust it.
   defp build_named_identity_filter(identity, parsed_identity) when is_map(parsed_identity) do
-    Enum.map(identity.keys, fn key ->
-      value =
-        case Map.fetch(parsed_identity, key) do
-          {:ok, value} -> value
-          :error -> Map.get(parsed_identity, Atom.to_string(key))
-        end
-
-      {key, value}
-    end)
+    Enum.map(identity.keys, fn key -> {key, Map.fetch!(parsed_identity, key)} end)
   end
 
   defp get_expected_identity_keys(resource, identities) do

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -785,7 +785,14 @@ defmodule AshIntrospection.Rpc.Pipeline do
           resource_module
 
         {:typed_struct, module} ->
-          if function_exported?(module, field_names_callback, 0), do: module, else: nil
+          # `Code.ensure_loaded?/1` first: Elixir loads modules lazily, so
+          # `function_exported?/3` answers `false` for a consumer's struct
+          # module nothing has touched in this process, and the mapping module
+          # silently becomes `nil`. #49 swept the library for this; #52 guarded
+          # nine sites and left this one, because #44 held this file.
+          if Code.ensure_loaded?(module) and function_exported?(module, field_names_callback, 0),
+            do: module,
+            else: nil
 
         _ ->
           default_resource

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -193,6 +193,20 @@ defmodule AshIntrospection.Rpc.Pipeline do
   # Action Execution Helpers
   # ---------------------------------------------------------------------------
 
+  # `identity` is an update/destroy lookup key: `execute_update_action/3` and
+  # `execute_destroy_action/3` are its only consumers, and a read selects a
+  # record with `get_by`. A read used to carry `identity` as far as the query
+  # and then drop it, so the caller asked for one record and got the whole
+  # table back, or a `MultipleResults` from `Ash.read_one/1` naming nothing it
+  # could act on. Rejecting is what upstream `ash_typescript` already means:
+  # its `identities` option is empty for every action type but `:update` and
+  # `:destroy`, so no generated client can send it on a read. See the
+  # 2026-09-09 entry in `docs/decisions.md`.
+  defp execute_read_action(%Request{identity: identity} = request, _opts, _config)
+       when not is_nil(identity) do
+    {:error, {:identity_not_supported, %{action: request.action.name}}}
+  end
+
   defp execute_read_action(%Request{} = request, opts, config) do
     if Map.get(request.action, :get?, false) do
       with {:ok, query} <-

--- a/test/ash_introspection/rpc/error_builder_test.exs
+++ b/test/ash_introspection/rpc/error_builder_test.exs
@@ -47,4 +47,17 @@ defmodule AshIntrospection.Rpc.ErrorBuilderTest do
       assert error.path == [:identity]
     end
   end
+
+  describe "identity_not_supported" do
+    test "names the read action and keeps the placeholder against its vars" do
+      error =
+        ErrorBuilder.build_error_response({:identity_not_supported, %{action: :get_account}})
+
+      assert error.type == "identity_not_supported"
+      assert error.message =~ "%{action}"
+      assert error.vars == %{action: "get_account"}
+      assert error.path == [:identity]
+      assert error.details.suggestion =~ "get_by"
+    end
+  end
 end

--- a/test/ash_introspection/rpc/pipeline_identity_boolean_test.exs
+++ b/test/ash_introspection/rpc/pipeline_identity_boolean_test.exs
@@ -15,6 +15,10 @@ defmodule AshIntrospection.Rpc.PipelineIdentityBooleanTest do
   and `execute_destroy_action/3` (reads use `get_by`), so these tests exercise
   those two against three accounts that differ only in `:active` — `false`,
   `true` and `nil` — and assert which record changed and which did not.
+
+  Since #44 a genuinely `nil` identity value is rejected rather than compiled
+  to `active == nil`, so the `false`/`nil` distinction is now enforced from
+  both sides.
   """
   use ExUnit.Case, async: false
 
@@ -113,18 +117,31 @@ defmodule AshIntrospection.Rpc.PipelineIdentityBooleanTest do
                emails(ctx)
     end
 
-    test "an identity value of nil never resolves the false record", %{name: name} = ctx do
-      # `false` and `nil` must not be interchangeable. A nil identity value
-      # compiles to `active == nil`, which Ash evaluates as unknown and so
-      # matches no record — that is a separate concern from this fix, and the
-      # point here is only that it does not reach the `active: false` account.
-      assert {:error, %Ash.Error.Query.NotFound{}} =
+    test "an identity value of nil is rejected and changes nothing", %{name: name} = ctx do
+      # `false` and `nil` must not be interchangeable. Until #44 a nil value
+      # compiled to `active == nil`, which Ash evaluates as unknown, so the
+      # update failed as `NotFound` — an answer that reads as "no such record"
+      # when the real fault is an identity that cannot name one.
+      assert {:error, {:invalid_identity, %{message: message}}} =
                Pipeline.execute_ash_action(
                  update_request(%{name: name, active: nil}, %{email: "renamed@example.com"})
                )
 
+      assert message =~ "null"
+      assert message =~ "active"
+
       assert %{inactive: ctx.inactive.email, active: ctx.active.email, unset: ctx.unset.email} ==
                emails(ctx)
+    end
+
+    test "a nil identity value is rejected on destroy too and destroys nothing",
+         %{name: name} = ctx do
+      assert {:error, {:invalid_identity, %{message: _}}} =
+               Pipeline.execute_ash_action(destroy_request(%{name: name, active: nil}))
+
+      assert Ash.get!(Account, ctx.inactive.id)
+      assert Ash.get!(Account, ctx.active.id)
+      assert Ash.get!(Account, ctx.unset.id)
     end
   end
 

--- a/test/ash_introspection/rpc/pipeline_identity_on_read_test.exs
+++ b/test/ash_introspection/rpc/pipeline_identity_on_read_test.exs
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineIdentityOnReadTest do
+  @moduledoc """
+  `identity` is an update/destroy lookup key. Read actions look records up with
+  `get_by`, and until #44 a read carrying `identity` had it silently dropped:
+  the client asked for one record and got the whole table back, or a
+  `MultipleResults` error from `Ash.read_one/1` that named nothing useful.
+
+  These tests pin the rejection — a read with `identity` fails with
+  `:identity_not_supported` — and prove `get_by` still resolves the same lookup.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.Account
+  alias AshIntrospection.Test.RpcDomain
+
+  setup do
+    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
+
+    suffix = System.unique_integer([:positive])
+
+    alice =
+      Account
+      |> Ash.Changeset.for_create(:create, %{name: "Alice", email: "alice-#{suffix}@example.com"})
+      |> Ash.create!()
+
+    bob =
+      Account
+      |> Ash.Changeset.for_create(:create, %{name: "Bob", email: "bob-#{suffix}@example.com"})
+      |> Ash.create!()
+
+    %{alice: alice, bob: bob}
+  end
+
+  defp request(action, attrs) do
+    Request.new(
+      Map.merge(
+        %{
+          domain: RpcDomain,
+          resource: Account,
+          action: Ash.Resource.Info.action(Account, action),
+          rpc_action: %{},
+          input: %{},
+          context: %{},
+          select: [:id, :name, :email],
+          load: [],
+          extraction_template: [:id, :name, :email]
+        },
+        attrs
+      )
+    )
+  end
+
+  describe "identity on a read action" do
+    test "a get? read carrying an identity is rejected by name", %{alice: alice} do
+      assert {:error, {:identity_not_supported, %{action: :get_account}}} =
+               Pipeline.execute_ash_action(request(:get_account, %{identity: alice.id}))
+    end
+
+    test "a list read carrying an identity is rejected", %{alice: alice} do
+      assert {:error, {:identity_not_supported, %{action: :read}}} =
+               Pipeline.execute_ash_action(request(:read, %{identity: alice.id}))
+    end
+
+    test "a map identity is rejected on a read", %{alice: alice} do
+      assert {:error, {:identity_not_supported, _}} =
+               Pipeline.execute_ash_action(
+                 request(:get_account, %{identity: %{email: alice.email}})
+               )
+    end
+
+    test "a read without an identity is untouched", %{alice: alice} do
+      assert {:ok, record} =
+               Pipeline.execute_ash_action(request(:get_account, %{get_by: %{id: alice.id}}))
+
+      assert record.id == alice.id
+    end
+
+    test "a list read without an identity still returns every record", %{
+      alice: alice,
+      bob: bob
+    } do
+      assert {:ok, records} = Pipeline.execute_ash_action(request(:read, %{}))
+
+      ids = MapSet.new(records, & &1.id)
+      assert MapSet.member?(ids, alice.id)
+      assert MapSet.member?(ids, bob.id)
+    end
+  end
+end


### PR DESCRIPTION
Closes #44.

The ticket carried three findings about identity handling. The first was a
judgement call, and it is what this PR mostly is.

## Decision: reads reject `identity`

A read action carrying `identity` now fails with `identity_not_supported`
naming the action. Reads select a record with `get_by`. Wiring `identity` into
the read path was rejected.

**The evidence.**

- Upstream `ash_typescript` already draws this line. `get_action_context/3`
  resolves `identities` to `[]` for every action type but `:update` and
  `:destroy` (`lib/ash_typescript/rpc/codegen/helpers/config_builder.ex:63-67`),
  and both the config type and the request payload gate on that list being
  non-empty. No generated TS client can send `identity` on a read. Its
  `rpc-action-options.md` says the same in words: "Control how records are
  located for update and destroy actions."
- Wiring it up would have needed rules upstream has never written.
  `identities` defaults to `[:_primary_key]`, and `maybe_apply_identity_filter/5`
  errors with `missing_identity` when the identity is absent but the list is
  not empty. Reads would have needed their own default of `[]`, so the symmetry
  with update and destroy was never real.
- The consumer's Kotlin generator gates on the same empty list and never sends
  it. Its **Swift** generator does: `generate_get_function/3` at
  `lib/ash_kotlin_multiplatform/swift/codegen.ex:581-594` emits `identity: id`
  for every `get?` read. Those calls were returning the wrong record. They now
  fail by name.

Silence was the option the ticket ruled out, and it was not theoretical — the
new test reproduces the exact `Ash.Error.Invalid.MultipleResults` the #15 agent
hit before the fix.

Recorded as a dated entry in `docs/decisions.md`, with what it cost.

## The other two findings

**A `nil` identity value matched nothing.** It compiled to `key == nil`, which
Ash evaluates as unknown, so the caller saw `NotFound` — an answer that reads
as "no such record" when the fault is an identity that cannot name one. It is
now rejected as `invalid_identity`.

Building `is_nil(key)` instead would have been worse. Ash identities default to
`nils_distinct?: true` (`deps/ash/lib/ash/resource/identity.ex:48`), so a null
key does not identify a single record; `execute_update_action/3` and
`execute_destroy_action/3` then take `Ash.Query.limit(query, 1)` and would
mutate an arbitrary match. That is the same widening #8 closed for map and list
operands, so the null is rejected on the same path, one guard earlier.

**The string-key fallback in `build_named_identity_filter/2` is deleted.**
`build_identity_filter/3` selects a named identity only when `Map.has_key?/2`
holds for every atom key, so `Map.fetch/2` never missed. Replaced with
`Map.fetch!/2` plus a comment stating the invariant that makes it safe.

## Also: the last bare `function_exported?/3` (#49)

#52 swept the repo for bare `function_exported?/3` calls on consumer-supplied
modules and guarded nine, skipping `get_field_mapping_module/3` in
`rpc/pipeline.ex` because this branch held the file. It was the only bare site
left in `lib/`; it is now guarded with `Code.ensure_loaded?/1` like its
neighbours. That finishes the sweep. #49 is already closed by #52, so this PR
does not close it again.

**It ships without a test, deliberately.** Both outcomes of that branch — the
consumer's struct module, or `nil` — reach
`ResultProcessor.get_field_type_info/3`, which answers `{nil, []}` either way.
Measured: the whole suite passes with the branch hard-coded to `nil` (281
tests, 0 failures). A test asserting the guard would not fail on the bug, so
none was written and `CLAUDE.md` now records why, so the next reader does not
delete the guard for lack of coverage.

## Test plan

`main` was at 274 tests after #52 merged; this branch is at **281, 0
failures**. All five CI gates run clean locally:

```
mix format --check-formatted   OK
mix compile --force --warnings-as-errors   no warnings
mix test                       281 tests, 0 failures
mix hex.audit                  No retired packages found
mix deps.audit                 No vulnerabilities found.
```

New coverage in `test/ash_introspection/rpc/pipeline_identity_on_read_test.exs`:

- a `get?` read with a scalar `identity` is rejected by action name
- a list read with `identity` is rejected
- a map `identity` on a read is rejected
- a read with `get_by` and no identity still resolves the right record
- a list read with no identity still returns every record

Extended in `pipeline_identity_boolean_test.exs`, keeping #15's and #8's
coverage intact:

- a `nil` identity value on update is rejected and changes nothing (this
  assertion changed from `NotFound`; it is the proof of the behaviour change)
- a `nil` identity value on destroy is rejected and destroys nothing
- the `false` and `true` identity cases from #15 still pass unchanged

And in `error_builder_test.exs`: `identity_not_supported` keeps its own `type`,
its `%{action}` placeholder against its `vars`, and its `[:identity]` path.

## Breaking change

Both rejections turn a silent wrong answer into an error, so they are breaking
for anyone relying on the old behaviour. `CHANGELOG.md` carries both under
Unreleased → Changed. `ash_kotlin_multiplatform` has to move its generated
Swift `getX(id:)` reads to `get_by` before taking this release.

## Documentation

Per `CLAUDE.md`, in this PR:

- `docs/decisions.md` — the dated entry: decision, why, cost.
- `docs/risks.md` — T2 ("one consumer, no contract test") gains the realised
  instance; T3's test count corrected.
- `docs/roadmap.md` — an entry alongside #52's in Unreleased, #44 dropped
  from Next, and #52's "one site remains" note updated now that it does not.
- `CLAUDE.md` — the #49 lesson corrected to ten guarded sites, plus a note
  that one of them is unobservable and why.
- `CHANGELOG.md`, `README.md` — the identity/`get_by` split stated.

No `docs/architecture.md` change: no new module and no new dependency edge.

## Not verified

`ash_kotlin_multiplatform` was read, not run. Nothing here proves its Swift
`getX(id:)` calls behave as described at runtime — that reading is from
`swift/codegen.ex`, and the repo has no contract test with this one (risk T2).
