### PR TITLE
fix: type discovery and return-type classification (#21, #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to
   ([#44](https://github.com/udin-io/ash_introspection/issues/44)). It used to
   compile to `key == nil`, which Ash evaluates as unknown, so the lookup
   matched nothing and surfaced as `NotFound`.
+- `AshIntrospection.Codegen.TypeDiscovery` accepts an optional
+  `get_rpc_action_entrypoints` config callback
+  ([#21](https://github.com/udin-io/ash_introspection/issues/21)). It returns
+  `%{resource: module, action: atom}` maps or `{module, atom}` tuples, and
+  scopes discovery to those actions: a read, create, update or destroy
+  entrypoint keeps the resource's own fields in scope, a generic action reaches
+  only its own arguments, `:returns` and metadata. Omitting the key keeps the
+  previous whole-resource scope, so no consumer has to act.
+- `action_returns_field_selectable_type?/1` distinguishes a resource from a
+  plain typed struct
+  ([#22](https://github.com/udin-io/ash_introspection/issues/22)).
+  `Ash.Type.Struct` accepts any struct module as `:instance_of`, and every one
+  used to come back as `{:ok, :resource, module}`, sending field selection off
+  to build a load statement against a module with no data layer. A non-resource
+  `instance_of` now returns `{:ok, :typed_struct, {module, fields}}`, or
+  `{:error, :not_field_selectable_type}` when it declares no fields. Both were
+  already documented returns of this function; a consumer matching only
+  `{:ok, :resource, _}` for such an action sees the change.
 
 ### Fixed
 
@@ -42,6 +60,30 @@ and this project adheres to
   `%Ash.Vector{}` keeps its floats in a packed binary that `Jason` refuses to
   encode, so selecting a vector field either crashed the encoder or put
   `%{data: <<...>>, dimensions: n}` on the wire.
+- Type discovery unwraps NewTypes before reading constraints
+  ([#21](https://github.com/udin-io/ash_introspection/issues/21)). A NewType
+  keeps its `:types`, `:fields` and `:instance_of` on itself, so the wrapper's
+  raw constraints are empty: a union behind one contributed no members and its
+  embedded resources reached no generator.
+- Type discovery finds an embedded resource named directly as an action
+  argument ([#21](https://github.com/udin-io/ash_introspection/issues/21)).
+  Discovery matched only bare `Ash.Type.Struct` and then excluded embedded
+  resources on purpose, so a client got no type for an argument it has to
+  build.
+- Type discovery walks calculation arguments, action arguments, a generic
+  action's `:returns` and a read action's metadata
+  ([#21](https://github.com/udin-io/ash_introspection/issues/21)). It covered
+  attributes, calculations and aggregates only.
+- `classify_return_type/2` unwraps NewTypes, so a generic action returning one
+  is no longer refused field selection on a shape that supports it
+  ([#22](https://github.com/udin-io/ash_introspection/issues/22)).
+- `Ash.Type.Duration` classifies as a primitive
+  ([#22](https://github.com/udin-io/ash_introspection/issues/22)). It reaches a
+  client as one ISO 8601 string and has no fields to select.
+- `classify_error_type/2` reads a custom type's `interop_type_name/0` off the
+  original type rather than the unwrapped subtype
+  ([#22](https://github.com/udin-io/ash_introspection/issues/22)). A NewType
+  declaring its own interop name was routed to the container branch instead.
 
 ## [0.3.0] - 2026-09-09
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,35 @@ only a module with a `.beam` file on disk can be loaded back. Unloading is
 global to the VM, so such a file is `async: false`. See
 `test/ash_introspection/lazy_module_loading_test.exs`.
 
+### The `Test.Account` suite flakes on a torn-down ETS table
+
+**Symptom.** Roughly one full `mix test` run in twelve fails on `main` with no
+source change, always in a file that writes `AshIntrospection.Test.Account`:
+`PipelineFilterInjectionTest`, `PipelineIdentityOnReadTest`,
+`PipelineIdentityBooleanTest` or `ValueFormatterVectorTest`. The message is
+either `record with id: "..." not found` or, uncovered, the real one:
+
+```
+** (ArgumentError) errors were found at the given arguments:
+  * 1st argument: the table identifier does not refer to an existing ETS table
+```
+
+Measured 2026-09-09 at `91ecead`: 7 failures in 87 consecutive runs of the
+untouched suite. **It is not your change.** Re-run before you start bisecting.
+
+**Why.** Five test files call `Ash.DataLayer.Ets.stop(Account)` from `on_exit`
+(`pipeline_filter_injection_test.exs:21`,
+`pipeline_identity_on_read_test.exs:23`, `value_formatter_vector_test.exs:29`,
+`pipeline_identity_boolean_test.exs:31`,
+`error_builder_bulk_errors_test.exs:29`). There is one ETS table per resource
+for the whole VM, so that teardown is global. Every one of those files is
+`async: false`, so the ordering that breaks it has not been pinned down — the
+table reference a test holds simply stops existing under it.
+
+**What we do.** Nothing yet; no ticket owns it. Do not add a sixth
+`Ash.DataLayer.Ets.stop/1`, and do not claim a green suite from one run — run
+`mix test` a few times before calling a change clean.
+
 ### No stdlib `JSON`: `mix.exs` declares `elixir: "~> 1.15"`
 
 **Symptom.** Code using the `JSON` module compiles on your machine and fails on

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,6 +153,7 @@ flowchart LR
     tdisc --> tsi
     vet --> tsi
     actint --> vet
+    actint --> tsi
 ```
 
 Measured 2026-09-09: `ash_kotlin_multiplatform` names `AshIntrospection` at 35

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -36,6 +36,16 @@ port the rest against the manifest instead of against live introspection.
 Re-porting each fix onto live introspection is the expensive path and it is the
 one we are on until #23 lands.
 
+**A port can now be partial, which is new.** #21 landed the behaviour of
+upstream `437901f` by hand, because upstream's own version of that commit calls
+`Ash.Info.Manifest.Generator.Reachability` and there is nothing here to call.
+Discovery scopes to declared entrypoints by action kind: a read, create, update
+or destroy entrypoint keeps the whole resource in scope, a generic action keeps
+only what it names. Upstream is finer — it walks each action's accepted
+attributes, loads and relationship depth — so this repo still over-discovers
+for a resource whose read action exposes fields no client asks for. A partial
+port reads as a closed issue in the log and is not one; #23 carries the rest.
+
 ### T2 — One consumer, no contract test
 
 **The risk.** `ash_kotlin_multiplatform` depends on `ash_introspection ~> 0.2.0`
@@ -72,7 +82,7 @@ yet and is not on the board.
 **The risk.** `lib/ash_introspection/rpc/` had **zero** test coverage until the
 week of 2026-09-09 (#18). Coverage arrived as regression tests attached to the
 seven fixes shipped in 0.3.0 — one test per fixed bug, not a suite that
-describes the pipeline. `main` is at 281 tests, and whole modules
+describes the pipeline. `main` is at 301 tests, and whole modules
 (`value_formatter.ex`, `field_extractor.ex`, `atomizer.ex`) are still exercised
 only incidentally.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,26 @@ which come first. Numbers in parentheses are GitHub issues on
   `get_by`, the same split upstream `ash_typescript` draws. A read carrying
   `identity` used to build no filter at all. Breaking for the consumer's
   generated Swift clients — see [decisions.md](decisions.md).
+- **Fix type discovery: NewType unwrapping, action arguments, entrypoint
+  scoping** (#21). Traversal read the raw constraints of a NewType, so a union
+  behind one contributed no members. An embedded resource named directly as an
+  action argument was excluded on purpose. Calculation arguments, action
+  arguments, a generic action's `:returns` and a read action's metadata were
+  never walked at all. Discovery now also takes an optional
+  `get_rpc_action_entrypoints` config callback, so a resource exposing only a
+  generic action stops pulling every embedded type off its attributes into the
+  generated output. Ports `ash_typescript` `8a4051f` and `d981ba6`, and the
+  intent of `437901f`; the finer-grained reachability upstream gets from
+  `Ash.Info.Manifest` waits on #23.
+- **Fix return-type and validation-error classification** (#22).
+  `classify_return_type/2` was handed the wrapper rather than the unwrapped
+  type, so a generic action returning a NewType was refused field selection on
+  a shape that supports it; and every `Ash.Type.Struct` carrying `:instance_of`
+  was reported as a resource, including a plain struct with no data layer.
+  `Ash.Type.Duration` is now a primitive. `classify_error_type/2` reads a
+  custom type's interop name off the original type rather than the unwrapped
+  subtype. Ports `ash_typescript` `88783c0`, `618851b`, `ecb1364` and
+  `a74c551`.
 
 ### 0.3.0 — 2026-09-09
 
@@ -73,7 +93,10 @@ dozen other items.
 1. **#23 — adopt `Ash.Info.Manifest`.** Upstream replaced live introspection
    with a precomputed Spark manifest in `ash` 3.32.3. This repo still calls
    `Ash.Resource.Info` at ~66 sites, which is why upstream's type-discovery
-   fixes do not port cleanly. Blocks #19, #20, #21, #22, #24, #25, #26 and more.
+   fixes do not port cleanly. Blocks #19, #20, #24, #25, #26 and more, and
+   carries the remainder of #21: entrypoint scoping here branches on the action
+   kind, where upstream's `Reachability` walks the accepted attributes, loads
+   and relationship depth of each declared action.
 2. **Correctness fixes that need no manifest**: #40 (second `rescue` in
    `process_single_error` has no `catch` clause), #35 (tuple nested selection
    keys its template from the raw wire name), #16 (a list of errors in

--- a/lib/ash_introspection/codegen/action_introspection.ex
+++ b/lib/ash_introspection/codegen/action_introspection.ex
@@ -81,6 +81,8 @@ defmodule AshIntrospection.Codegen.ActionIntrospection do
   including resources, typed maps, typed structs, and primitives.
   """
 
+  alias AshIntrospection.TypeSystem.Introspection
+
   # Container types that can have field constraints for field selection
   @field_constrained_types [Ash.Type.Map, Ash.Type.Keyword, Ash.Type.Tuple]
 
@@ -338,6 +340,11 @@ defmodule AshIntrospection.Codegen.ActionIntrospection do
   defp check_action_returns(action) do
     {base_type, constraints, is_array} = unwrap_return_type(action)
 
+    # A NewType keeps `:fields` and `:instance_of` on itself, so the wrapper
+    # arrives with empty constraints and classifies as a bare atom. Unwrap to
+    # match the runtime field selector, which sees the underlying type.
+    {base_type, constraints} = Introspection.unwrap_new_type(base_type, constraints)
+
     case classify_return_type(base_type, constraints) do
       {:resource, module} ->
         if is_array do
@@ -389,9 +396,23 @@ defmodule AshIntrospection.Codegen.ActionIntrospection do
           | {:error, atom()}
   defp classify_return_type(type, constraints) do
     cond do
-      # Ash.Type.Struct with instance_of - represents a resource
+      # Ash.Type.Struct with instance_of - a resource, or a plain typed struct.
+      # `instance_of` accepts any struct module, so treating every one as a
+      # resource sent field selection off to build a load statement against a
+      # module with no data layer.
       type == Ash.Type.Struct and Keyword.has_key?(constraints, :instance_of) ->
-        {:resource, Keyword.get(constraints, :instance_of)}
+        instance_of = Keyword.get(constraints, :instance_of)
+
+        cond do
+          Ash.Resource.Info.resource?(instance_of) ->
+            {:resource, instance_of}
+
+          Keyword.has_key?(constraints, :fields) ->
+            {:typed_struct, {instance_of, Keyword.get(constraints, :fields, [])}}
+
+          true ->
+            {:error, :not_field_selectable_type}
+        end
 
       # Ash.Type.Struct without instance_of - error
       type == Ash.Type.Struct ->

--- a/lib/ash_introspection/codegen/type_discovery.ex
+++ b/lib/ash_introspection/codegen/type_discovery.ex
@@ -634,6 +634,11 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
 
   defp traverse_type_with_visited(type, constraints, current_path, visited)
        when is_list(constraints) do
+    # A NewType keeps its own constraints, so the wrapper's raw constraints are
+    # empty and every `:types`, `:fields` and `:instance_of` below would read as
+    # missing. Unwrap before matching on the type.
+    {type, constraints} = Introspection.unwrap_new_type(type, constraints)
+
     case type do
       {:array, inner_type} ->
         items_constraints = Keyword.get(constraints, :items, [])

--- a/lib/ash_introspection/codegen/type_discovery.ex
+++ b/lib/ash_introspection/codegen/type_discovery.ex
@@ -295,13 +295,19 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   @doc """
   Finds all Ash resources used as struct arguments in RPC actions.
 
-  Scans all RPC actions for arguments with type `:struct` or `Ash.Type.Struct`
-  that have an `instance_of` constraint pointing to an Ash resource.
+  Scans the given actions' public arguments for:
+
+    * `:struct` or `Ash.Type.Struct` with an `instance_of` constraint pointing
+      at an Ash resource,
+    * an embedded resource named directly as the argument's type,
+    * either of the above behind a NewType wrapper or an array.
+
+  Embedded resources are included. A generator that skipped them produced no
+  type for an argument a client has to construct.
 
   ## Parameters
 
-    * `otp_app` - The OTP application name
-    * `config` - Configuration map with `get_rpc_action_info`
+    * `actions` - A list of action structs to scan
 
   ## Returns
 
@@ -327,32 +333,28 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   end
 
   defp find_struct_resources_in_type(type, constraints) do
-    case type do
-      Ash.Type.Struct ->
+    {type, constraints} = Introspection.unwrap_new_type(type, constraints)
+
+    cond do
+      match?({:array, _}, type) ->
+        {:array, inner_type} = type
+        find_struct_resources_in_type(inner_type, Keyword.get(constraints, :items, []))
+
+      # An embedded resource is a type in its own right, so an argument can name
+      # it directly rather than going through `Ash.Type.Struct`.
+      Introspection.is_embedded_resource?(type) ->
+        [type]
+
+      type in [Ash.Type.Struct, :struct] ->
         instance_of = Keyword.get(constraints, :instance_of)
 
-        if instance_of && Spark.Dsl.is?(instance_of, Ash.Resource) &&
-             !Introspection.is_embedded_resource?(instance_of) do
+        if instance_of && Spark.Dsl.is?(instance_of, Ash.Resource) do
           [instance_of]
         else
           []
         end
 
-      :struct ->
-        instance_of = Keyword.get(constraints, :instance_of)
-
-        if instance_of && Spark.Dsl.is?(instance_of, Ash.Resource) &&
-             !Introspection.is_embedded_resource?(instance_of) do
-          [instance_of]
-        else
-          []
-        end
-
-      {:array, inner_type} ->
-        items_constraints = Keyword.get(constraints, :items, [])
-        find_struct_resources_in_type(inner_type, items_constraints)
-
-      _ ->
+      true ->
         []
     end
   end

--- a/lib/ash_introspection/codegen/type_discovery.ex
+++ b/lib/ash_introspection/codegen/type_discovery.ex
@@ -19,6 +19,12 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
     # Required: function to get RPC resources from otp_app
     get_rpc_resources: fn otp_app -> [...] end,
 
+    # Optional: function returning the declared action entrypoints, as
+    # %{resource: module, action: atom} maps or {module, atom} tuples.
+    # Supplying it scopes discovery to those actions; omitting it keeps every
+    # public action and field of every RPC resource in scope.
+    get_rpc_action_entrypoints: fn otp_app -> [...] end,
+
     # Optional: callback name for field names (default: :interop_field_names)
     field_names_callback: :interop_field_names,
 
@@ -59,6 +65,7 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
 
   @type config :: %{
           optional(:get_rpc_resources) => (atom() -> [module()]),
+          optional(:get_rpc_action_entrypoints) => (atom() -> [map() | {module(), atom()}]),
           optional(:field_names_callback) => atom(),
           optional(:has_language_extension?) => (module() -> boolean()),
           optional(:language_name) => String.t()
@@ -67,9 +74,13 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   @doc """
   Finds all Ash resources referenced by RPC resources.
 
-  Recursively scans all public attributes, calculations, and aggregates of RPC resources,
-  traversing complex types like maps with fields, unions, typed structs, etc., to find
-  any Ash resource references.
+  Recursively scans the public attributes, calculations (with their arguments)
+  and aggregates of each entrypoint resource, plus each entrypoint action's
+  arguments, `:returns` type and metadata, traversing complex types like maps
+  with fields, unions and typed structs to find any Ash resource references.
+
+  Entrypoints come from `get_rpc_action_entrypoints` when the config supplies
+  it, and otherwise from `get_rpc_resources` with every public action in scope.
 
   ## Parameters
 
@@ -81,12 +92,10 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   A list of unique Ash resource modules that are referenced by RPC resources.
   """
   def scan_rpc_resources(otp_app, config) do
-    get_rpc_resources = Map.fetch!(config, :get_rpc_resources)
-    rpc_resources = get_rpc_resources.(otp_app)
-
-    rpc_resources
-    |> Enum.reduce({[], MapSet.new()}, fn resource, {acc, visited} ->
-      {found, new_visited} = scan_rpc_resource(resource, visited)
+    otp_app
+    |> discovery_entrypoints(config)
+    |> Enum.reduce({[], MapSet.new()}, fn {resource, action_scope}, {acc, visited} ->
+      {found, new_visited} = scan_entrypoint(resource, action_scope, visited)
       {acc ++ found, new_visited}
     end)
     |> elem(0)
@@ -94,8 +103,45 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
     |> Enum.uniq()
   end
 
+  # Returns `[{resource, action_scope}]` in declaration order, where the scope is
+  # either `:all_actions` or an explicit list of action names.
+  defp discovery_entrypoints(otp_app, config) do
+    case Map.get(config, :get_rpc_action_entrypoints) do
+      nil ->
+        get_rpc_resources = Map.fetch!(config, :get_rpc_resources)
+
+        Enum.map(get_rpc_resources.(otp_app), &{&1, :all_actions})
+
+      get_rpc_action_entrypoints ->
+        pairs =
+          otp_app
+          |> get_rpc_action_entrypoints.()
+          |> Enum.flat_map(&normalize_entrypoint/1)
+
+        by_resource = Enum.group_by(pairs, &elem(&1, 0), &elem(&1, 1))
+
+        pairs
+        |> Enum.map(&elem(&1, 0))
+        |> Enum.uniq()
+        |> Enum.map(fn resource -> {resource, Enum.uniq(by_resource[resource])} end)
+    end
+  end
+
+  defp normalize_entrypoint(%{resource: resource, action: action}), do: [{resource, action}]
+
+  defp normalize_entrypoint({resource, action}) when is_atom(resource) and is_atom(action),
+    do: [{resource, action}]
+
+  defp normalize_entrypoint(_), do: []
+
   @doc """
   Discovers embedded resources from RPC resources by scanning and filtering.
+
+  When `config` carries `get_rpc_action_entrypoints`, only the declared actions
+  are treated as entrypoints: a resource exposing nothing but a generic action
+  contributes only what that action names, not every embedded type hanging off
+  its attributes. Without that key every public action and field of every RPC
+  resource is in scope.
 
   ## Parameters
 

--- a/lib/ash_introspection/codegen/type_discovery.ex
+++ b/lib/ash_introspection/codegen/type_discovery.ex
@@ -49,6 +49,10 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   - `{:union_member, :type_name}` - Union member
   - `{:array_items}` - Array items
   - `{:map_field, :field_name}` - Map field
+  - `{:action, :action_name}` - Action
+  - `{:argument, :argument_name}` - Action or calculation argument
+  - `{:metadata, :metadata_name}` - Action metadata
+  - `:returns` - Generic action return type
   """
 
   alias AshIntrospection.TypeSystem.Introspection
@@ -138,6 +142,11 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   @doc """
   Scans a single resource to find all referenced resources.
 
+  Covers the resource's public attributes, calculations (including their
+  arguments) and aggregates, plus every public action's arguments, `:returns`
+  type and metadata. An action is part of a resource's public surface, so a
+  type it names is a type the client has to be able to build or read.
+
   ## Parameters
 
     * `resource` - An Ash resource module
@@ -150,8 +159,100 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
     * `updated_visited` - Updated MapSet of visited resources
   """
   def scan_rpc_resource(resource, visited \\ MapSet.new()) do
+    scan_entrypoint(resource, :all_actions, visited)
+  end
+
+  defp scan_entrypoint(resource, action_scope, visited) do
     path = [{:root, resource}]
-    find_referenced_resources_with_visited(resource, path, visited)
+    actions = entrypoint_actions(resource, action_scope)
+
+    {field_resources, visited} =
+      if scan_resource_fields?(action_scope, actions) do
+        find_referenced_resources_with_visited(resource, path, visited)
+      else
+        {[], visited}
+      end
+
+    {action_resources, visited} = traverse_actions(actions, path, visited)
+
+    {field_resources ++ action_resources, visited}
+  end
+
+  defp entrypoint_actions(resource, :all_actions) do
+    resource
+    |> Ash.Resource.Info.actions()
+    |> Enum.filter(&Map.get(&1, :public?, true))
+  end
+
+  defp entrypoint_actions(resource, action_names) when is_list(action_names) do
+    action_names
+    |> Enum.map(&Ash.Resource.Info.action(resource, &1))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # A read, create, update or destroy action hands back the resource itself, so
+  # its attributes, calculations and aggregates are all reachable. A generic
+  # action reaches only what it names.
+  defp scan_resource_fields?(:all_actions, _actions), do: true
+
+  defp scan_resource_fields?(action_names, actions) when is_list(action_names) do
+    Enum.any?(actions, &(&1.type != :action))
+  end
+
+  defp traverse_actions(actions, current_path, visited) do
+    Enum.reduce(actions, {[], visited}, fn action, {acc, visited} ->
+      {found, visited} = traverse_action(action, current_path, visited)
+      {acc ++ found, visited}
+    end)
+  end
+
+  defp traverse_action(action, current_path, visited) do
+    action_path = current_path ++ [{:action, action.name}]
+
+    {argument_resources, visited} =
+      action.arguments
+      |> Enum.filter(&Map.get(&1, :public?, true))
+      |> Enum.reduce({[], visited}, fn argument, {acc, visited} ->
+        {found, visited} =
+          traverse_type_with_visited(
+            argument.type,
+            argument.constraints || [],
+            action_path ++ [{:argument, argument.name}],
+            visited
+          )
+
+        {acc ++ found, visited}
+      end)
+
+    {return_resources, visited} =
+      case Map.get(action, :returns) do
+        nil ->
+          {[], visited}
+
+        returns ->
+          traverse_type_with_visited(
+            returns,
+            Map.get(action, :constraints) || [],
+            action_path ++ [:returns],
+            visited
+          )
+      end
+
+    {metadata_resources, visited} =
+      (Map.get(action, :metadata) || [])
+      |> Enum.reduce({[], visited}, fn metadata, {acc, visited} ->
+        {found, visited} =
+          traverse_type_with_visited(
+            metadata.type,
+            metadata.constraints || [],
+            action_path ++ [{:metadata, metadata.name}],
+            visited
+          )
+
+        {acc ++ found, visited}
+      end)
+
+    {argument_resources ++ return_resources ++ metadata_resources, visited}
   end
 
   @doc """
@@ -442,6 +543,10 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
   defp format_path_segment({:union_member, name}), do: "(union member: #{name})"
   defp format_path_segment(:array_items), do: "[]"
   defp format_path_segment({:map_field, name}), do: to_string(name)
+  defp format_path_segment({:action, name}), do: "(action: #{name})"
+  defp format_path_segment({:argument, name}), do: "(argument: #{name})"
+  defp format_path_segment({:metadata, name}), do: "(metadata: #{name})"
+  defp format_path_segment(:returns), do: "(returns)"
 
   defp format_path_segment({:relationship_path, names}) do
     "(via relationships: #{Enum.join(names, " -> ")})"
@@ -596,10 +701,26 @@ defmodule AshIntrospection.Codegen.TypeDiscovery do
         Enum.reduce(calculations, {[], visited}, fn calc, {acc, visited} ->
           calc_path = current_path ++ [{:calculation, calc.name}]
 
-          {found, new_visited} =
+          {found, visited} =
             traverse_type_with_visited(calc.type, calc.constraints || [], calc_path, visited)
 
-          {acc ++ found, new_visited}
+          # A calculation argument is client-supplied, so its type needs
+          # generating even when nothing else in the resource mentions it.
+          {argument_found, visited} =
+            (Map.get(calc, :arguments) || [])
+            |> Enum.reduce({[], visited}, fn argument, {arg_acc, visited} ->
+              {found, visited} =
+                traverse_type_with_visited(
+                  argument.type,
+                  argument.constraints || [],
+                  calc_path ++ [{:argument, argument.name}],
+                  visited
+                )
+
+              {arg_acc ++ found, visited}
+            end)
+
+          {acc ++ found ++ argument_found, visited}
         end)
 
       {aggregate_resources, visited} =

--- a/lib/ash_introspection/codegen/validation_error_types.ex
+++ b/lib/ash_introspection/codegen/validation_error_types.ex
@@ -123,7 +123,12 @@ defmodule AshIntrospection.Codegen.ValidationErrorTypes do
   def classify_error_type(nil, _constraints), do: {:ok, {:primitive_errors, nil}}
 
   def classify_error_type(type, constraints) do
-    # Unwrap NewTypes FIRST (consistent with ValueFormatter pattern)
+    # Unwrapping serves the complex-type branches below, which need the subtype's
+    # merged constraints. It must not come first for anything the consumer
+    # declares on the type itself: a NewType names its own interop type and its
+    # subtype does not carry that name. Any callback added here later — an
+    # interop error name, a serializer hook — is read off the ORIGINAL `type`
+    # for the same reason.
     {unwrapped_type, full_constraints} = Introspection.unwrap_new_type(type, constraints)
 
     classification =
@@ -135,9 +140,10 @@ defmodule AshIntrospection.Codegen.ValidationErrorTypes do
           {:ok, inner_classification} = classify_error_type(inner_type, inner_constraints)
           {:array_errors, inner_classification}
 
-        # Custom types with interop_type_name (check before embedded resource)
-        Introspection.is_custom_interop_type?(unwrapped_type) ->
-          {:custom_type_errors, unwrapped_type}
+        # Custom types with interop_type_name, read off the original type so a
+        # NewType keeps the name it declares for itself
+        Introspection.is_custom_interop_type?(type) ->
+          {:custom_type_errors, type}
 
         # Embedded resources
         Introspection.is_embedded_resource?(unwrapped_type) ->

--- a/lib/ash_introspection/type_system/introspection.ex
+++ b/lib/ash_introspection/type_system/introspection.ex
@@ -55,6 +55,9 @@ defmodule AshIntrospection.TypeSystem.Introspection do
       Ash.Type.DateTime,
       Ash.Type.NaiveDatetime,
       Ash.Type.UtcDatetime,
+      # A %Duration{} is a struct, but it carries no selectable fields: a client
+      # receives it as one ISO 8601 scalar.
+      Ash.Type.Duration,
       Ash.Type.Atom,
       Ash.Type.UUID,
       Ash.Type.Binary

--- a/test/ash_introspection/codegen/action_introspection_test.exs
+++ b/test/ash_introspection/codegen/action_introspection_test.exs
@@ -231,6 +231,38 @@ defmodule AshIntrospection.Codegen.ActionIntrospectionTest do
                )
     end
 
+    test "returns typed_map for a NewType wrapping a map with fields" do
+      result =
+        ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_task_stats))
+
+      assert {:ok, :typed_map, fields} = result
+      assert Keyword.has_key?(fields, :is_active?)
+      assert Keyword.has_key?(fields, :task_count)
+      assert Keyword.has_key?(fields, :meta_1)
+    end
+
+    test "returns resource for a NewType wrapping a struct over a resource" do
+      assert {:ok, :resource, AshIntrospection.Test.User} =
+               ActionIntrospection.action_returns_field_selectable_type?(
+                 get_action(:get_featured_user)
+               )
+    end
+
+    test "returns typed_struct for a struct whose instance_of is not a resource" do
+      assert {:ok, :typed_struct, {AshIntrospection.Test.Suggestion, fields}} =
+               ActionIntrospection.action_returns_field_selectable_type?(get_action(:suggest))
+
+      assert Keyword.has_key?(fields, :name)
+      assert Keyword.has_key?(fields, :score)
+    end
+
+    test "returns error for a non-resource struct with no field constraints" do
+      assert {:error, :not_field_selectable_type} =
+               ActionIntrospection.action_returns_field_selectable_type?(
+                 get_action(:opaque_suggestion)
+               )
+    end
+
     test "returns error for primitive return types" do
       assert {:error, :not_field_selectable_type} =
                ActionIntrospection.action_returns_field_selectable_type?(get_action(:get_count))

--- a/test/ash_introspection/codegen/type_discovery_test.exs
+++ b/test/ash_introspection/codegen/type_discovery_test.exs
@@ -15,7 +15,10 @@ defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
   alias AshIntrospection.Test.{
     Document,
     EmbeddedAttachment,
+    EmbeddedAudit,
+    EmbeddedFilter,
     EmbeddedNote,
+    EmbeddedRendered,
     User,
     WrappedContent
   }
@@ -45,6 +48,28 @@ defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
 
     test "find_struct_argument_resources/1 unwraps a NewType over a struct" do
       assert User in TypeDiscovery.find_struct_argument_resources([action(:attach)])
+    end
+  end
+
+  describe "types reachable only through an action or a calculation argument" do
+    setup do
+      %{discovered: TypeDiscovery.find_embedded_resources(:ash_introspection, config())}
+    end
+
+    test "finds the type of a calculation argument", %{discovered: discovered} do
+      assert EmbeddedFilter in discovered
+    end
+
+    test "finds the type of a generic action argument", %{discovered: discovered} do
+      assert EmbeddedAttachment in discovered
+    end
+
+    test "finds a generic action's return type", %{discovered: discovered} do
+      assert EmbeddedRendered in discovered
+    end
+
+    test "finds the type of a read action's metadata", %{discovered: discovered} do
+      assert EmbeddedAudit in discovered
     end
   end
 end

--- a/test/ash_introspection/codegen/type_discovery_test.exs
+++ b/test/ash_introspection/codegen/type_discovery_test.exs
@@ -19,6 +19,8 @@ defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
     EmbeddedFilter,
     EmbeddedNote,
     EmbeddedRendered,
+    EmbeddedUnscoped,
+    Ledger,
     User,
     WrappedContent
   }
@@ -70,6 +72,51 @@ defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
 
     test "finds the type of a read action's metadata", %{discovered: discovered} do
       assert EmbeddedAudit in discovered
+    end
+  end
+
+  describe "entrypoint scoping" do
+    defp entrypoint_config(resources, entrypoints) do
+      %{
+        get_rpc_resources: fn _otp_app -> resources end,
+        get_rpc_action_entrypoints: fn _otp_app -> entrypoints end
+      }
+    end
+
+    test "without declared entrypoints every public action and field is in scope" do
+      discovered =
+        TypeDiscovery.find_embedded_resources(
+          :ash_introspection,
+          %{get_rpc_resources: fn _otp_app -> [Ledger] end}
+        )
+
+      assert EmbeddedUnscoped in discovered
+    end
+
+    test "a generic action entrypoint does not reach the resource's own fields" do
+      config = entrypoint_config([Ledger], [%{resource: Ledger, action: :ping}])
+
+      refute EmbeddedUnscoped in TypeDiscovery.find_embedded_resources(:ash_introspection, config)
+    end
+
+    test "a read action entrypoint does reach the resource's own fields" do
+      config = entrypoint_config([Ledger], [%{resource: Ledger, action: :read}])
+
+      assert EmbeddedUnscoped in TypeDiscovery.find_embedded_resources(:ash_introspection, config)
+    end
+
+    test "a resource with no declared entrypoint contributes nothing" do
+      config = entrypoint_config([Document, Ledger], [%{resource: Document, action: :attach}])
+      discovered = TypeDiscovery.find_embedded_resources(:ash_introspection, config)
+
+      assert EmbeddedAttachment in discovered
+      refute EmbeddedUnscoped in discovered
+    end
+
+    test "entrypoints may be given as {resource, action} tuples" do
+      config = entrypoint_config([Ledger], [{Ledger, :read}])
+
+      assert EmbeddedUnscoped in TypeDiscovery.find_embedded_resources(:ash_introspection, config)
     end
   end
 end

--- a/test/ash_introspection/codegen/type_discovery_test.exs
+++ b/test/ash_introspection/codegen/type_discovery_test.exs
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
+  @moduledoc """
+  Discovery tests for issue #21. Each test names one route by which a type
+  reaches an entrypoint resource, and one embedded resource reachable only by
+  that route.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Codegen.TypeDiscovery
+
+  alias AshIntrospection.Test.{
+    Document,
+    EmbeddedNote,
+    WrappedContent
+  }
+
+  defp config, do: %{get_rpc_resources: fn _otp_app -> [Document] end}
+
+  describe "NewType-wrapped unions" do
+    test "traverse_type/2 finds members of a union hidden behind a NewType" do
+      assert TypeDiscovery.traverse_type(WrappedContent, []) == [EmbeddedNote]
+    end
+
+    test "traverse_type/2 finds members through an array of NewType-wrapped unions" do
+      assert TypeDiscovery.traverse_type({:array, WrappedContent}, []) == [EmbeddedNote]
+    end
+
+    test "find_embedded_resources/2 reaches a union member behind a NewType attribute" do
+      assert EmbeddedNote in TypeDiscovery.find_embedded_resources(:ash_introspection, config())
+    end
+  end
+end

--- a/test/ash_introspection/codegen/type_discovery_test.exs
+++ b/test/ash_introspection/codegen/type_discovery_test.exs
@@ -14,11 +14,15 @@ defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
 
   alias AshIntrospection.Test.{
     Document,
+    EmbeddedAttachment,
     EmbeddedNote,
+    User,
     WrappedContent
   }
 
   defp config, do: %{get_rpc_resources: fn _otp_app -> [Document] end}
+
+  defp action(name), do: Ash.Resource.Info.action(Document, name)
 
   describe "NewType-wrapped unions" do
     test "traverse_type/2 finds members of a union hidden behind a NewType" do
@@ -31,6 +35,16 @@ defmodule AshIntrospection.Codegen.TypeDiscoveryTest do
 
     test "find_embedded_resources/2 reaches a union member behind a NewType attribute" do
       assert EmbeddedNote in TypeDiscovery.find_embedded_resources(:ash_introspection, config())
+    end
+  end
+
+  describe "struct arguments" do
+    test "find_struct_argument_resources/1 finds an embedded resource used directly" do
+      assert EmbeddedAttachment in TypeDiscovery.find_struct_argument_resources([action(:attach)])
+    end
+
+    test "find_struct_argument_resources/1 unwraps a NewType over a struct" do
+      assert User in TypeDiscovery.find_struct_argument_resources([action(:attach)])
     end
   end
 end

--- a/test/ash_introspection/codegen/validation_error_types_test.exs
+++ b/test/ash_introspection/codegen/validation_error_types_test.exs
@@ -6,7 +6,7 @@ defmodule AshIntrospection.Codegen.ValidationErrorTypesTest do
   use ExUnit.Case, async: true
 
   alias AshIntrospection.Codegen.ValidationErrorTypes
-  alias AshIntrospection.Test.{EmbeddedAddress, CustomType, Post, User}
+  alias AshIntrospection.Test.{EmbeddedAddress, CustomType, Post, User, WrappedCustomType}
 
   # ─────────────────────────────────────────────────────────────────
   # Basic Type Classification Tests
@@ -76,6 +76,11 @@ defmodule AshIntrospection.Codegen.ValidationErrorTypesTest do
     test "classifies custom type with interop_type_name" do
       assert {:ok, {:custom_type_errors, CustomType}} =
                ValidationErrorTypes.classify_error_type(CustomType, [])
+    end
+
+    test "keeps the name a NewType declares for itself rather than its subtype's" do
+      assert {:ok, {:custom_type_errors, WrappedCustomType}} =
+               ValidationErrorTypes.classify_error_type(WrappedCustomType, [])
     end
   end
 

--- a/test/ash_introspection/type_system/introspection_test.exs
+++ b/test/ash_introspection/type_system/introspection_test.exs
@@ -34,6 +34,10 @@ defmodule AshIntrospection.TypeSystem.IntrospectionTest do
       assert Introspection.is_primitive_type?(Ash.Type.UUID)
     end
 
+    test "returns true for Duration, which carries no selectable fields" do
+      assert Introspection.is_primitive_type?(Ash.Type.Duration)
+    end
+
     test "returns false for complex types" do
       refute Introspection.is_primitive_type?(Ash.Type.Union)
       refute Introspection.is_primitive_type?(Ash.Type.Map)

--- a/test/support/discovery_resources.ex
+++ b/test/support/discovery_resources.ex
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.EmbeddedNote do
+  @moduledoc """
+  Embedded resource reachable only through a member of a NewType-wrapped union.
+
+  Nothing else in the test suite references it, so discovering it proves that
+  traversal unwrapped `AshIntrospection.Test.WrappedContent` before reading its
+  `:types` constraint.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute(:body, :string, public?: true)
+  end
+end
+
+defmodule AshIntrospection.Test.WrappedContent do
+  @moduledoc """
+  A NewType over a union. The union's `:types` constraint lives on the NewType,
+  not on the wrapper, so any traversal that reads the raw constraints of
+  `WrappedContent` sees an empty keyword list and misses every member.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :union,
+    constraints: [
+      types: [
+        note: [type: AshIntrospection.Test.EmbeddedNote],
+        plain: [type: :string]
+      ]
+    ]
+end
+
+defmodule AshIntrospection.Test.DiscoveryDomain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource(AshIntrospection.Test.Document)
+  end
+end
+
+defmodule AshIntrospection.Test.Document do
+  @moduledoc """
+  The entrypoint resource for the type-discovery tests.
+
+  Every embedded type it can reach is reachable through exactly one route, so a
+  discovery test names both the type it expects and the defect that hides it.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.DiscoveryDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true)
+    attribute(:content, AshIntrospection.Test.WrappedContent, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+end

--- a/test/support/discovery_resources.ex
+++ b/test/support/discovery_resources.ex
@@ -33,6 +33,29 @@ defmodule AshIntrospection.Test.WrappedContent do
     ]
 end
 
+defmodule AshIntrospection.Test.EmbeddedAttachment do
+  @moduledoc """
+  Embedded resource reachable only as the direct type of a generic action
+  argument — never through an attribute, a calculation or an aggregate.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute(:filename, :string, public?: true)
+  end
+end
+
+defmodule AshIntrospection.Test.WrappedUser do
+  @moduledoc """
+  A NewType over `Ash.Type.Struct`. Its `:instance_of` constraint is invisible
+  on the wrapper, so an argument typed with it hides `Test.User` from any
+  scan that reads raw constraints.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :struct,
+    constraints: [instance_of: AshIntrospection.Test.User]
+end
+
 defmodule AshIntrospection.Test.DiscoveryDomain do
   @moduledoc false
   use Ash.Domain
@@ -61,5 +84,12 @@ defmodule AshIntrospection.Test.Document do
 
   actions do
     defaults([:read, :destroy, create: :*, update: :*])
+
+    action :attach, :boolean do
+      argument(:attachment, AshIntrospection.Test.EmbeddedAttachment)
+      argument(:author, AshIntrospection.Test.WrappedUser)
+
+      run(fn _input, _context -> {:ok, true} end)
+    end
   end
 end

--- a/test/support/discovery_resources.ex
+++ b/test/support/discovery_resources.ex
@@ -78,6 +78,19 @@ defmodule AshIntrospection.Test.EmbeddedRendered do
   end
 end
 
+defmodule AshIntrospection.Test.EmbeddedUnscoped do
+  @moduledoc """
+  Embedded resource reachable from `AshIntrospection.Test.Ledger`'s attributes
+  and from nothing else, so it is out of reach of any entrypoint set that
+  declares only Ledger's generic action.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute(:note, :string, public?: true)
+  end
+end
+
 defmodule AshIntrospection.Test.WrappedUser do
   @moduledoc """
   A NewType over `Ash.Type.Struct`. Its `:instance_of` constraint is invisible
@@ -95,6 +108,31 @@ defmodule AshIntrospection.Test.DiscoveryDomain do
 
   resources do
     resource(AshIntrospection.Test.Document)
+    resource(AshIntrospection.Test.Ledger)
+  end
+end
+
+defmodule AshIntrospection.Test.Ledger do
+  @moduledoc """
+  Resource whose only embedded type hangs off an attribute. Declaring just its
+  generic action as an entrypoint must leave that type undiscovered; declaring
+  a read action must reach it.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.DiscoveryDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:trail, AshIntrospection.Test.EmbeddedUnscoped, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+
+    action :ping, :boolean do
+      run(fn _input, _context -> {:ok, true} end)
+    end
   end
 end
 

--- a/test/support/discovery_resources.ex
+++ b/test/support/discovery_resources.ex
@@ -45,6 +45,39 @@ defmodule AshIntrospection.Test.EmbeddedAttachment do
   end
 end
 
+defmodule AshIntrospection.Test.EmbeddedFilter do
+  @moduledoc """
+  Embedded resource reachable only as the type of a calculation argument.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute(:term, :string, public?: true)
+  end
+end
+
+defmodule AshIntrospection.Test.EmbeddedAudit do
+  @moduledoc """
+  Embedded resource reachable only as the type of a read action's metadata.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute(:actor_label, :string, public?: true)
+  end
+end
+
+defmodule AshIntrospection.Test.EmbeddedRendered do
+  @moduledoc """
+  Embedded resource reachable only as a generic action's `:returns` type.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute(:html, :string, public?: true)
+  end
+end
+
 defmodule AshIntrospection.Test.WrappedUser do
   @moduledoc """
   A NewType over `Ash.Type.Struct`. Its `:instance_of` constraint is invisible
@@ -82,14 +115,29 @@ defmodule AshIntrospection.Test.Document do
     attribute(:content, AshIntrospection.Test.WrappedContent, public?: true)
   end
 
+  calculations do
+    calculate :summary, :string, expr(title) do
+      public?(true)
+      argument(:filter, AshIntrospection.Test.EmbeddedFilter)
+    end
+  end
+
   actions do
     defaults([:read, :destroy, create: :*, update: :*])
+
+    read :audited do
+      metadata(:audit, AshIntrospection.Test.EmbeddedAudit)
+    end
 
     action :attach, :boolean do
       argument(:attachment, AshIntrospection.Test.EmbeddedAttachment)
       argument(:author, AshIntrospection.Test.WrappedUser)
 
       run(fn _input, _context -> {:ok, true} end)
+    end
+
+    action :render, AshIntrospection.Test.EmbeddedRendered do
+      run(fn _input, _context -> {:ok, nil} end)
     end
   end
 end

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -102,6 +102,27 @@ defmodule AshIntrospection.Test.TaskStats do
   end
 end
 
+defmodule AshIntrospection.Test.Suggestion do
+  @moduledoc """
+  A plain struct that is not an Ash resource. It is the shape `instance_of` can
+  legally carry with no data layer behind it — the case return-type
+  classification used to mistake for a resource, sending field selection off to
+  build a load statement against nothing.
+  """
+  defstruct [:name, :score]
+end
+
+defmodule AshIntrospection.Test.FeaturedUser do
+  @moduledoc """
+  A NewType over `Ash.Type.Struct`. Its `:instance_of` constraint lives on the
+  NewType, so classifying the wrapper sees a bare atom with empty constraints
+  and refuses field selection on a shape that supports it.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :struct,
+    constraints: [instance_of: AshIntrospection.Test.User]
+end
+
 defmodule AshIntrospection.Test.CustomType do
   @moduledoc """
   A custom type with interop_type_name callback.
@@ -241,6 +262,36 @@ defmodule AshIntrospection.Test.Post do
     action :get_task_stats, AshIntrospection.Test.TaskStats do
       run fn _input, _context ->
         {:ok, %{is_active?: true, task_count: 0, meta_1: "none"}}
+      end
+    end
+
+    # Generic action returning a NewType that wraps a struct over a resource
+    action :get_featured_user, AshIntrospection.Test.FeaturedUser do
+      run fn _input, _context ->
+        {:ok, nil}
+      end
+    end
+
+    # Generic action returning a plain struct that is not an Ash resource
+    action :suggest, :struct do
+      constraints instance_of: AshIntrospection.Test.Suggestion,
+                  fields: [
+                    name: [type: :string],
+                    score: [type: :integer]
+                  ]
+
+      run fn _input, _context ->
+        {:ok, %AshIntrospection.Test.Suggestion{name: "Test", score: 1}}
+      end
+    end
+
+    # Generic action returning a struct with neither a resource nor field
+    # constraints, so nothing can be selected from it
+    action :opaque_suggestion, :struct do
+      constraints instance_of: AshIntrospection.Test.Suggestion
+
+      run fn _input, _context ->
+        {:ok, %AshIntrospection.Test.Suggestion{name: "Test", score: 1}}
       end
     end
 

--- a/test/support/resources.ex
+++ b/test/support/resources.ex
@@ -102,6 +102,19 @@ defmodule AshIntrospection.Test.TaskStats do
   end
 end
 
+defmodule AshIntrospection.Test.WrappedCustomType do
+  @moduledoc """
+  A NewType that names its own interop type. Unwrapping it first yields
+  `Ash.Type.Map`, which carries no such callback, so the declared name is lost
+  and the type is routed to the wrong error category.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [fields: [label: [type: :string]]]
+
+  def interop_type_name, do: "WrappedCustom"
+end
+
 defmodule AshIntrospection.Test.Suggestion do
   @moduledoc """
   A plain struct that is not an Ash resource. It is the shape `instance_of` can


### PR DESCRIPTION
Closes #21
Closes #22

Seven type-system correctness defects ported by hand from `ash_typescript`.
They ship together because several share one root cause: a type is inspected
without unwrapping its NewType wrapper first, so `:types`, `:fields` and
`:instance_of` all read as missing on the wrapper.

`main` was at 281 tests; this branch is at 301, 0 failures.

## What changed

| Defect | Upstream | File |
|---|---|---|
| Traversal read a NewType's raw constraints, so a union behind one contributed no members | `8a4051f` | `codegen/type_discovery.ex` |
| An embedded resource named directly as an action argument was excluded on purpose | `d981ba6` | `codegen/type_discovery.ex` |
| Calculation arguments, action arguments, `:returns` and metadata were never walked | — | `codegen/type_discovery.ex` |
| Discovery scanned whole resources rather than declared entrypoints | `437901f` (partial) | `codegen/type_discovery.ex` |
| `classify_return_type/2` was handed the wrapper, refusing field selection on a shape that supports it | `88783c0` | `codegen/action_introspection.ex` |
| Every `Ash.Type.Struct` with `:instance_of` came back as a resource, including plain structs with no data layer | `618851b` | `codegen/action_introspection.ex` |
| `Ash.Type.Duration` was not a primitive | `ecb1364` | `type_system/introspection.ex` |
| A custom type's interop name was read off the unwrapped subtype | `a74c551` | `codegen/validation_error_types.ex` |

### One issue's premise was wrong

#22 records `a74c551` as "a design constraint to honour rather than a fix",
on the reading that this repo has no custom-type branch yet. It does:
`validation_error_types.ex:139` called `is_custom_interop_type?(unwrapped_type)`,
which is exactly the upstream bug. It is fixed here with a failing test
(`AshIntrospection.Test.WrappedCustomType`, a NewType declaring its own
`interop_type_name/0`), and the comment on the unwrap now states the rule so
the next callback added there is checked on the original type.

## Consumer-visible changes

Neither breaks a caller that already handles the documented return shapes.

- **`TypeDiscovery` gains an optional `get_rpc_action_entrypoints` config key.**
  It returns `%{resource: module, action: atom}` maps or `{module, atom}`
  tuples. Omitting it keeps the previous whole-resource scope, so
  `ash_kotlin_multiplatform` needs no change to keep working — its
  `RpcConfigCollector.get_rpc_resources_and_actions/1` already holds the data
  to opt in.
- **`action_returns_field_selectable_type?/1` can now return
  `{:ok, :typed_struct, {module, fields}}` or
  `{:error, :not_field_selectable_type}`** where it previously returned
  `{:ok, :resource, module}`, for an `instance_of` that is not an Ash resource.
  Both shapes were already documented returns of that function.

## Deferred to #23

Upstream's `437901f` delegates to `Ash.Info.Manifest.Generator.Reachability`,
which lives in the `ash` package. This repo has not adopted the manifest, so
the traversal is hand-written against the config map it does have, and the
scoping is coarser than upstream's:

- **What landed.** A read, create, update or destroy entrypoint keeps the
  resource's attributes, calculations and aggregates in scope. A generic action
  reaches only its own arguments, `:returns` and metadata. A resource with an
  RPC block but no declared action contributes nothing.
- **What did not.** Upstream walks each action's accepted attributes, its
  `load` statements and its relationship depth, so it also drops fields a
  declared read action never exposes. This repo still over-discovers there.

`docs/risks.md` T1 carries the caveat, and `docs/roadmap.md` names it under
#23, so a closed #21 does not read as the whole of upstream `437901f`.

## Also in this PR

`CLAUDE.md` gains a lesson on a **pre-existing** suite flake found while
verifying this work: roughly 1 run in 12 fails on untouched `main`, always in a
file that writes `AshIntrospection.Test.Account`, with
`the table identifier does not refer to an existing ETS table`. Five test files
call `Ash.DataLayer.Ets.stop(Account)` from `on_exit` against one globally
shared table. Measured at `91ecead`: 7 failures in 87 consecutive runs with no
source change. Nothing here fixes it and no ticket owns it; it is written down
so the next session re-runs rather than bisecting its own change.

## Test plan

Every defect has a failing-first test asserting observable behaviour through
the public API, driven by a fixture that actually exhibits the shape.

- `test/support/discovery_resources.ex` — new. `Document` reaches five
  embedded resources by exactly one route each: a NewType-wrapped union member,
  a direct generic-action argument, a calculation argument, a read action's
  metadata and a generic action's `:returns`. `Ledger` carries an embedded type
  on an attribute only, so entrypoint scoping is testable both ways.
- `test/support/resources.ex` — adds `Suggestion` (a plain struct that is not
  a resource), `FeaturedUser` (a NewType over a struct), `WrappedCustomType`
  (a NewType declaring `interop_type_name/0`), and three actions on `Post`.
- `test/ash_introspection/codegen/type_discovery_test.exs` — new, 14 tests.
- `action_introspection_test.exs`, `validation_error_types_test.exs`,
  `type_system/introspection_test.exs` — one test per remaining defect.

Verified locally on the five CI gates: `mix format --check-formatted`,
`mix compile --force --warnings-as-errors` (no warnings), `mix test`
(301 tests, 0 failures), `mix hex.audit` and `mix deps.audit` (both clean).
