### PR TITLE
fix: format action metadata once, by its declared type (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,25 @@ and this project adheres to
 
 ### Fixed
 
+- Action metadata is formatted once, by the type its action declared for it
+  ([#20](https://github.com/udin-io/ash_introspection/issues/20)). A metadata
+  name is not an attribute, so stage 4 looked it up on the resource, found
+  nothing and passed the value through: the nested keys of a typed-map
+  metadata value reached the client in snake_case inside a camelCase response.
+  Values now go through the same `ValueFormatter` dispatch attributes use, at
+  extraction, where the declaration is readable.
+- Metadata values are no longer formatted a second time by the response
+  envelope ([#20](https://github.com/udin-io/ash_introspection/issues/20)).
+  Only the top-level metadata names are formatted there. Formatting a value
+  twice is not idempotent: a field pinned to the client name `_rev` by its
+  type's `interop_field_names/0` came out as `rev`.
+- A metadata field declared as an unconstrained `:map` reaches the client with
+  its keys intact
+  ([#20](https://github.com/udin-io/ash_introspection/issues/20)). An
+  unconstrained map is an explicit opt-out of typing, so its keys belong to
+  whoever wrote them. The guarantee holds on
+  `Rpc.Pipeline.format_output_with_request/3`, which has the types;
+  `format_output/2` has no request and still formats every key it reaches.
 - A failing bulk action reaches the client as one error per failed field
   ([#16](https://github.com/udin-io/ash_introspection/issues/16)).
   `Ash.bulk_create/update/destroy` return `%Ash.BulkResult{errors: [...]}` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,26 @@ only a module with a `.beam` file on disk can be loaded back. Unloading is
 global to the VM, so such a file is `async: false`. See
 `test/ash_introspection/lazy_module_loading_test.exs`.
 
+### A casing assertion cannot see double formatting
+
+**Symptom.** You suspect a value is being formatted twice, write a test that
+asserts the final key casing, and it passes against both the buggy and the
+fixed code.
+
+**Why.** `FieldFormatter.format_field_name/2` is idempotent for ordinary
+names: `changed_by` camelizes to `changedBy`, and `changedBy` is already
+camelCase so a second pass returns it unchanged. The same holds for digits and
+leading underscores — `_id` and `field_1_name` both settle after one pass
+(measured 2026-09-09 across `_id`, `_type`, `_created_at`, `field_1_name`,
+`meta_1`, `a__b`, `id_`, `http_url`, `v2_token`). So a double-formatting bug is
+invisible to a casing assertion.
+
+**What we do.** Reach for a name the formatter cannot derive. A NewType with
+`interop_field_names/0` pins its client names, and a pinned name that is not
+camelCase changes under a second pass: `AshIntrospection.Test.RevisionInfo`
+maps `:revision` to `_rev`, which a second camelization rewrites to `rev`. See
+`test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs`.
+
 ### The `Test.Account` suite flakes on a torn-down ETS table
 
 **Symptom.** Roughly one full `mix test` run in twelve fails on `main` with no
@@ -245,7 +265,7 @@ mix hex.audit
 mix deps.audit
 ```
 
-`main` is at **281 tests, 0 failures**. A pull request that changes that number
+`main` is at **309 tests, 0 failures**. A pull request that changes that number
 downward, or that leaves a compiler warning, is not finished. Never suppress a
 warning — fix the cause.
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -32,8 +32,8 @@ the `mix ash_introspection.upgrade` codemod task.
 |---|---|---|
 | [architecture.md](architecture.md) | What the pieces are, who calls what, which modules the consumer actually uses | Current as of 0.3.0 |
 | [roadmap.md](roadmap.md) | What shipped, what is open with ticket numbers, what is next, what was declined | Current as of 0.3.0; 19 issues open |
-| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | 3 live technical risks, 1 operational, 1 product |
-| [decisions.md](decisions.md) | The choices that still shape the library, dated, with what each cost | 6 entries, latest 2026-09-09 |
+| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | 4 live technical risks, 1 operational, 1 product |
+| [decisions.md](decisions.md) | The choices that still shape the library, dated, with what each cost | 9 entries, latest 2026-09-09 |
 
 ## Keeping this current
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,6 +13,54 @@ recorded nowhere in the repo. This page replaces ADRs; there is no `adr/`
 directory here and none should be created. A decision that no longer shapes the
 code is deleted, not archived, because git keeps the history.
 
+## 2026-09-09 — The metadata allowlist stays with the caller
+
+**Decided.** This pipeline extracts exactly the metadata fields
+`Request.show_metadata` names. Deciding **which** fields a client may ask for
+was left out on purpose. Issue #20.
+
+**Why.** There is nothing here to hang it on. Upstream `ash_typescript`
+filters the requested list in its parse stage; this library has no parse
+stage, because `parse_request/3` lives in each language-specific wrapper.
+Building one to hold a single check would duplicate a stage that already
+exists downstream, and `ash_kotlin_multiplatform`'s `Rpc.Runner` already has
+the check: `dsl_metadata_fields/2` reads the allowlist off the RPC DSL and
+`narrow_metadata_fields/2` intersects the client's request with it, so a
+client can only narrow, never widen.
+
+**Cost.** A responsibility that is documented rather than enforced. A future
+wrapper that pipes client input into `Request.show_metadata` unfiltered
+exposes every metadata field its actions declare, and nothing here stops it or
+says so at compile time. The "Action metadata" section of `Rpc.Pipeline`'s
+`@moduledoc` names the obligation; that is the whole of the enforcement.
+
+## 2026-09-09 — Metadata is formatted by its declared type
+
+**Decided.** An action's metadata values are formatted once, at extraction, by
+the type the action declared for them — the same `ValueFormatter` dispatch an
+attribute goes through. The response envelope then formats the top-level
+metadata name and nothing below it. A metadata field declared as an
+unconstrained `:map` reaches the client verbatim. Issue #20.
+
+**Why.** The type is only knowable at extraction. A metadata name is not an
+attribute, so the stage-4 resource lookup finds nothing and passes the value
+through — which is how a typed map's nested keys reached the client in
+snake_case inside a camelCase response. Moving the formatting to where the
+declaration is readable fixes that, and it forces the envelope to stop
+recursing, because formatting a value twice is not idempotent in general: a
+field pinned to the client name `_rev` came out as `rev`.
+
+Unconstrained maps are excluded because declaring `:map` with no field
+constraints is a statement, not an omission. The caller said the shape is not
+the type system's business; renaming its keys contradicts that, and the keys
+that get renamed — `_id`, `_rev`, anything with a leading underscore — are
+exactly the wire names a client cannot reconstruct.
+
+**Cost.** The guarantee is narrower than the pipeline's output surface. It
+holds on `format_output_with_request/3`, which has the types, and not on
+`format_output/2`, which does not — and `format_output/2` is what
+`ash_kotlin_multiplatform` calls. See risk T4 in [risks.md](risks.md).
+
 ## 2026-09-09 — `identity` is an update/destroy key; reads reject it
 
 **Decided.** A read action carrying `identity` fails with

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -82,7 +82,7 @@ yet and is not on the board.
 **The risk.** `lib/ash_introspection/rpc/` had **zero** test coverage until the
 week of 2026-09-09 (#18). Coverage arrived as regression tests attached to the
 seven fixes shipped in 0.3.0 — one test per fixed bug, not a suite that
-describes the pipeline. `main` is at 301 tests, and whole modules
+describes the pipeline. `main` is at 309 tests, and whole modules
 (`value_formatter.ex`, `field_extractor.ex`, `atomizer.ex`) are still exercised
 only incidentally.
 
@@ -95,6 +95,37 @@ runs the suite on every pull request as of #32.
 
 **What we would do.** Keep landing a regression test with each fix, per #18's
 own preference, and treat a fix that arrives without one as unfinished.
+
+### T4 — Two stage-4 exits, and the consumer uses the untyped one
+
+**The risk.** `Rpc.Pipeline` exposes two stage-4 functions.
+`format_output_with_request/3` has the `%Request{}`, so it formats each value
+by its declared type; `format_output/2` has no request and falls back to
+`FieldFormatter.format_output_field_names/2`, which rewrites every key it can
+reach. The type-driven guarantees #20 landed — a typed map's nested keys
+camelized, a pinned interop name kept, an unconstrained `:map` passed through
+verbatim — hold on the first function only.
+
+**Why it bites.** `ash_kotlin_multiplatform` calls the second one.
+`AshKotlinMultiplatform.Rpc.Runner.run_action/4` ends with
+`Pipeline.format_output(processed)` (`lib/ash_kotlin_multiplatform/rpc/runner.ex:157`),
+so the consumer's successful responses never see the typed path. Its clients
+still get `_id` rewritten to `id` inside an unconstrained map. The library is
+correct and the deployed behaviour is not, which is the worst shape a fix can
+take: a green suite here and no change downstream.
+
+**What we watch.** `grep -rn 'Pipeline.format_output' lib/` in the consumer.
+Measured 2026-09-09: the only live call is the untyped `format_output/1` in
+`Runner`; the consumer's own `format_output/2` wraps
+`format_output_with_request/3` and appears nowhere but its moduledoc example.
+Any new wrapper is checked against the "Action metadata" section of
+`Rpc.Pipeline`'s `@moduledoc` before it ships.
+
+**What we would do.** Move the consumer to `format_output_with_request/3`; it
+already builds the `%Request{}` two lines earlier, so the change is one line
+plus its tests. That is a ticket in `ash_kotlin_multiplatform`, not here.
+Collapsing the two functions into one is the larger answer and needs the
+error-response path, which legitimately has no request, to keep working.
 
 ## Operational
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,20 @@ which come first. Numbers in parentheses are GitHub issues on
 
 ### Unreleased
 
+- **Format action metadata once, and by its declared type** (#20). A metadata
+  name is not an attribute, so stage 4 looked it up on the resource, found
+  nothing, and handed the value back untouched: the nested keys of a typed-map
+  metadata value reached the client in snake_case inside a camelCase response.
+  The mutation path had the opposite fault — it camelized the whole metadata
+  map recursively, which renamed the keys inside an unconstrained `:map`, an
+  explicit opt-out of typing whose keys belong to the caller. Values are now
+  formatted at extraction through the same `ValueFormatter` dispatch attributes
+  use, which is why `add_read_metadata/5` and `add_mutation_metadata/5` thread
+  `request.action`, and the response envelope formats only the top-level
+  metadata names. Ports `ash_typescript` `8a05642`, `9e5d05a` and `919e817`.
+  The allowlist half of upstream's metadata fix belongs to a parse stage this
+  library does not have; see [decisions.md](decisions.md) and risk T4 in
+  [risks.md](risks.md).
 - **Guard every consumer-module callback check with `Code.ensure_loaded?/1`**
   (#49). `function_exported?/3` answers `false` for a module the VM has not
   loaded, and Elixir loads lazily, so a domain, resource or type nothing had
@@ -93,7 +107,7 @@ dozen other items.
 1. **#23 — adopt `Ash.Info.Manifest`.** Upstream replaced live introspection
    with a precomputed Spark manifest in `ash` 3.32.3. This repo still calls
    `Ash.Resource.Info` at ~66 sites, which is why upstream's type-discovery
-   fixes do not port cleanly. Blocks #19, #20, #24, #25, #26 and more, and
+   fixes do not port cleanly. Blocks #19, #24, #25, #26 and more, and
    carries the remainder of #21: entrypoint scoping here branches on the action
    kind, where upstream's `Reachability` walks the accepted attributes, loads
    and relationship depth of each declared action.

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -38,6 +38,32 @@ defmodule AshIntrospection.Rpc.Pipeline do
 
   This allows each language generator to customize the behavior while
   sharing the core pipeline logic.
+
+  ## Action metadata
+
+  `Request.show_metadata` names the metadata fields stage 3 extracts, and this
+  pipeline extracts exactly what it is given. **Deciding which metadata fields
+  a client may ask for is the caller's job, not this pipeline's.** There is no
+  parse stage here — `parse_request/3` lives in the language-specific wrapper
+  — so nothing in this library filters a client-supplied field list against
+  the action's declaration. A wrapper that passes client input into
+  `show_metadata` unfiltered lets a client read any metadata field the action
+  declares. `ash_kotlin_multiplatform` does filter, in
+  `AshKotlinMultiplatform.Rpc.Runner`: `dsl_metadata_fields/2` reads the
+  allowlist off the RPC DSL and `narrow_metadata_fields/2` intersects the
+  client's request with it, so a client can only narrow, never widen. Upstream
+  `ash_typescript` puts the same check in its own parse stage.
+
+  Each extracted value is formatted once, by the type its action declared for
+  it, and the response envelope then formats only the top-level metadata name.
+  A metadata field declared as an unconstrained `:map` is an explicit opt-out
+  of typing: its keys are the caller's and reach the client verbatim.
+
+  That guarantee holds on `format_output_with_request/3`, which has the request
+  and therefore the types. `format_output/2` has neither, so it falls back to
+  formatting every key it can reach — including the keys inside an
+  unconstrained map. A wrapper that wants type-correct output has to call
+  `format_output_with_request/3`.
   """
 
   alias AshIntrospection.{ErrorFormatter, FieldFormatter}

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -687,7 +687,16 @@ defmodule AshIntrospection.Rpc.Pipeline do
         base_response
 
       meta when is_map(meta) ->
-        formatted_metadata = FieldFormatter.format_output_field_names(meta, formatter)
+        # Only the top-level metadata names are formatted here. The values
+        # arrived from `extract_metadata_fields/4` already formatted by their
+        # declared type, and formatting them again would undo that: a typed
+        # value pinned to the client name `_rev` becomes `rev`, and the keys of
+        # an unconstrained `:map` — an explicit opt-out of typing — get
+        # renamed out from under the caller who wrote them.
+        formatted_metadata =
+          Map.new(meta, fn {key, value} ->
+            {FieldFormatter.format_field_name(key, formatter), value}
+          end)
 
         Map.put(
           base_response,

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -723,30 +723,30 @@ defmodule AshIntrospection.Rpc.Pipeline do
   end
 
   defp format_resource_output(data, resource, formatter, config) do
-    value_formatter_config = %{
-      input_field_formatter: Map.get(config, :input_field_formatter, :camel_case),
-      output_field_formatter: formatter,
-      field_names_callback: Map.get(config, :field_names_callback, :interop_field_names),
-      get_original_field_name: Map.get(config, :get_original_field_name),
-      format_field_for_client: Map.get(config, :format_field_for_client)
-    }
-
-    ValueFormatter.format(data, resource, [], :output, value_formatter_config)
+    ValueFormatter.format(data, resource, [], :output, value_formatter_config(formatter, config))
   end
 
   defp format_generic_action_output(data, action, formatter, config) do
     return_type = action.returns
     constraints = action.constraints || []
 
-    value_formatter_config = %{
+    ValueFormatter.format(
+      data,
+      return_type,
+      constraints,
+      :output,
+      value_formatter_config(formatter, config)
+    )
+  end
+
+  defp value_formatter_config(formatter, config) do
+    %{
       input_field_formatter: Map.get(config, :input_field_formatter, :camel_case),
       output_field_formatter: formatter,
       field_names_callback: Map.get(config, :field_names_callback, :interop_field_names),
       get_original_field_name: Map.get(config, :get_original_field_name),
       format_field_for_client: Map.get(config, :format_field_for_client)
     }
-
-    ValueFormatter.format(data, return_type, constraints, :output, value_formatter_config)
   end
 
   # ---------------------------------------------------------------------------
@@ -836,7 +836,7 @@ defmodule AshIntrospection.Rpc.Pipeline do
   # Metadata Helpers
   # ---------------------------------------------------------------------------
 
-  defp add_metadata(filtered_result, original_result, %Request{} = request, _config) do
+  defp add_metadata(filtered_result, original_result, %Request{} = request, config) do
     if Enum.empty?(request.show_metadata) do
       filtered_result
     else
@@ -845,14 +845,18 @@ defmodule AshIntrospection.Rpc.Pipeline do
           add_read_metadata(
             filtered_result,
             original_result,
-            request.show_metadata
+            request.show_metadata,
+            request.action,
+            config
           )
 
         action_type when action_type in [:create, :update, :destroy] ->
           add_mutation_metadata(
             filtered_result,
             original_result,
-            request.show_metadata
+            request.show_metadata,
+            request.action,
+            config
           )
 
         _ ->
@@ -861,58 +865,89 @@ defmodule AshIntrospection.Rpc.Pipeline do
     end
   end
 
-  defp add_read_metadata(filtered_result, original_result, show_metadata)
+  defp add_read_metadata(filtered_result, original_result, show_metadata, action, config)
        when is_list(filtered_result) do
     if is_list(original_result) do
       Enum.zip(filtered_result, original_result)
       |> Enum.map(fn {filtered_record, original_record} ->
-        do_add_read_metadata(filtered_record, original_record, show_metadata)
+        do_add_read_metadata(filtered_record, original_record, show_metadata, action, config)
       end)
     else
       filtered_result
     end
   end
 
-  defp add_read_metadata(filtered_result, original_result, show_metadata)
+  defp add_read_metadata(filtered_result, original_result, show_metadata, action, config)
        when is_map(filtered_result) do
     if Map.has_key?(filtered_result, :results) do
       updated_results =
         Enum.zip(filtered_result[:results] || [], original_result.results)
         |> Enum.map(fn {filtered_record, original_record} ->
-          do_add_read_metadata(filtered_record, original_record, show_metadata)
+          do_add_read_metadata(filtered_record, original_record, show_metadata, action, config)
         end)
 
       Map.put(filtered_result, :results, updated_results)
     else
-      do_add_read_metadata(filtered_result, original_result, show_metadata)
+      do_add_read_metadata(filtered_result, original_result, show_metadata, action, config)
     end
   end
 
-  defp add_read_metadata(filtered_result, _original_result, _show_metadata) do
+  defp add_read_metadata(filtered_result, _original_result, _show_metadata, _action, _config) do
     filtered_result
   end
 
-  defp do_add_read_metadata(filtered_record, original_record, show_metadata)
+  defp do_add_read_metadata(filtered_record, original_record, show_metadata, action, config)
        when is_map(filtered_record) do
     metadata_map = Map.get(original_record, :__metadata__, %{})
-    extracted_metadata = extract_metadata_fields(metadata_map, show_metadata)
+    extracted_metadata = extract_metadata_fields(metadata_map, show_metadata, action, config)
     Map.merge(filtered_record, extracted_metadata)
   end
 
-  defp do_add_read_metadata(filtered_record, _original_record, _show_metadata) do
+  defp do_add_read_metadata(filtered_record, _original_record, _show_metadata, _action, _config) do
     filtered_record
   end
 
-  defp add_mutation_metadata(filtered_result, original_result, show_metadata) do
+  defp add_mutation_metadata(filtered_result, original_result, show_metadata, action, config) do
     metadata_map = Map.get(original_result, :__metadata__, %{})
-    extracted_metadata = extract_metadata_fields(metadata_map, show_metadata)
+    extracted_metadata = extract_metadata_fields(metadata_map, show_metadata, action, config)
     %{data: filtered_result, metadata: extracted_metadata}
   end
 
-  defp extract_metadata_fields(metadata_map, show_metadata) do
+  # Each metadata value is formatted by the type its action declared for it, the
+  # same type-driven dispatch attributes and calculations go through. That is
+  # the only place the value can be formatted correctly, because it is the only
+  # place the type is known: a metadata name is not an attribute, so stage 4
+  # looks it up on the resource, finds nothing and hands the value back
+  # untouched. Formatting here means stage 4 must not format these values a
+  # second time — see `format_output_data/4`.
+  #
+  # Keys stay internal atoms. Stage 4 formats the top-level metadata name, once.
+  defp extract_metadata_fields(metadata_map, show_metadata, action, config) do
+    metadata_defs = Map.get(action, :metadata) || []
+    formatter = Map.get(config, :output_field_formatter, :camel_case)
+    value_config = value_formatter_config(formatter, config)
+
     Enum.reduce(show_metadata, %{}, fn metadata_field, acc ->
-      Map.put(acc, metadata_field, Map.get(metadata_map, metadata_field))
+      {type, constraints} = metadata_field_type(metadata_defs, metadata_field)
+      value = Map.get(metadata_map, metadata_field)
+
+      Map.put(
+        acc,
+        metadata_field,
+        ValueFormatter.format(value, type, constraints, :output, value_config)
+      )
     end)
+  end
+
+  # A metadata field the action does not declare formats as `nil`, which
+  # `ValueFormatter.format/5` passes through unchanged. That is the same answer
+  # an unconstrained `:map` gets, and it is the right one: with no declared type
+  # there is nothing to format the value by.
+  defp metadata_field_type(metadata_defs, field_name) do
+    case Enum.find(metadata_defs, &(Map.get(&1, :name) == field_name)) do
+      nil -> {nil, []}
+      definition -> {Map.get(definition, :type), Map.get(definition, :constraints) || []}
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs
+++ b/test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs
@@ -7,14 +7,17 @@ defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
   Pins how action metadata reaches the client: formatted exactly once, and by
   the type the action declared for it.
 
-  Two failures lived here, both found in #20 against upstream `ash_typescript`
-  (`8a05642`, `9e5d05a`):
+  Three failures lived here, all found in #20 against upstream `ash_typescript`
+  (`8a05642`, `9e5d05a`, `919e817`):
 
   - The read path merged metadata into the record raw, so the nested keys of a
     typed-map metadata value arrived in snake_case inside a response that was
     camelCase everywhere else.
   - The mutation path camelized the whole metadata map recursively, so a value
     the type system had already formatted was formatted a second time.
+  - That same recursion renamed the keys inside an unconstrained `:map`. An
+    unconstrained map is an explicit opt-out of typing: its keys belong to
+    whoever wrote them and no formatter may touch them.
 
   `AshIntrospection.Test.RevisionInfo` is what makes a second formatting pass
   visible. Camelizing `changedBy` yields `changedBy` again, so double
@@ -33,6 +36,16 @@ defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
   alias AshIntrospection.Test.MetadataDomain
 
   @show_metadata [:audit_entry, :revision_info, :raw_audit]
+
+  # The unconstrained map the fixture's actions hand back, verbatim. Its keys
+  # are the caller's: a leading underscore, a snake_case word, and a nested map
+  # carrying both. Every one of them is a key the camel-case formatter would
+  # rewrite if it were allowed to.
+  @raw_audit %{
+    "_id" => "audit-1",
+    "field_name" => "title",
+    "nested" => %{"_rev" => "rev-7", "changed_by" => "ops-team"}
+  }
 
   defp request(overrides) do
     %{
@@ -112,6 +125,29 @@ defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
     test "only the metadata fields the request asked for reach the client" do
       assert ["revisionInfo"] ==
                Map.keys(mutation_metadata(%{show_metadata: [:revision_info]}))
+    end
+  end
+
+  describe "unconstrained maps" do
+    test "a read leaves the keys of an unconstrained map metadata value alone" do
+      %{"data" => data} = read_response()
+
+      assert @raw_audit == data["rawAudit"]
+    end
+
+    test "a mutation leaves the keys of an unconstrained map metadata value alone" do
+      assert @raw_audit == mutation_metadata()["rawAudit"]
+    end
+
+    test "a generic action returning an unconstrained map hands its keys back" do
+      assert %{"data" => @raw_audit} =
+               request(%{
+                 action: Ash.Resource.Info.action(AuditedRecord, :raw_payload),
+                 select: [],
+                 extraction_template: [],
+                 show_metadata: []
+               })
+               |> response()
     end
   end
 end

--- a/test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs
+++ b/test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs
@@ -7,10 +7,14 @@ defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
   Pins how action metadata reaches the client: formatted exactly once, and by
   the type the action declared for it.
 
-  The read path used to merge metadata into the record raw, so the nested keys
-  of a typed-map metadata value arrived in snake_case inside a response that
-  was camelCase everywhere else. Found in #20 against upstream `ash_typescript`
-  `8a05642`.
+  Two failures lived here, both found in #20 against upstream `ash_typescript`
+  (`8a05642`, `9e5d05a`):
+
+  - The read path merged metadata into the record raw, so the nested keys of a
+    typed-map metadata value arrived in snake_case inside a response that was
+    camelCase everywhere else.
+  - The mutation path camelized the whole metadata map recursively, so a value
+    the type system had already formatted was formatted a second time.
 
   `AshIntrospection.Test.RevisionInfo` is what makes a second formatting pass
   visible. Camelizing `changedBy` yields `changedBy` again, so double
@@ -68,6 +72,17 @@ defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
     |> response()
   end
 
+  defp mutation_metadata(overrides \\ %{}) do
+    base = %{
+      action: Ash.Resource.Info.action(AuditedRecord, :create_with_metadata),
+      input: %{title: "create-#{System.unique_integer([:positive])}"}
+    }
+
+    %{"metadata" => metadata} = base |> Map.merge(overrides) |> request() |> response()
+
+    metadata
+  end
+
   describe "read action metadata" do
     test "the nested keys of a typed map metadata value are camelized" do
       %{"data" => data} = read_response()
@@ -80,6 +95,23 @@ defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
       %{"data" => data} = read_response()
 
       assert %{"_rev" => "rev-7", "revisedBy" => "ops-team"} == data["revisionInfo"]
+    end
+  end
+
+  describe "mutation action metadata" do
+    test "the nested keys of a typed map metadata value are camelized" do
+      assert %{"changedBy" => "ops-team", "changeReason" => "nightly cleanup"} ==
+               mutation_metadata()["auditEntry"]
+    end
+
+    test "a client name pinned by the declared type survives the formatter" do
+      assert %{"_rev" => "rev-7", "revisedBy" => "ops-team"} ==
+               mutation_metadata()["revisionInfo"]
+    end
+
+    test "only the metadata fields the request asked for reach the client" do
+      assert ["revisionInfo"] ==
+               Map.keys(mutation_metadata(%{show_metadata: [:revision_info]}))
     end
   end
 end

--- a/test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs
+++ b/test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineMetadataFormattingTest do
+  @moduledoc """
+  Pins how action metadata reaches the client: formatted exactly once, and by
+  the type the action declared for it.
+
+  The read path used to merge metadata into the record raw, so the nested keys
+  of a typed-map metadata value arrived in snake_case inside a response that
+  was camelCase everywhere else. Found in #20 against upstream `ash_typescript`
+  `8a05642`.
+
+  `AshIntrospection.Test.RevisionInfo` is what makes a second formatting pass
+  visible. Camelizing `changedBy` yields `changedBy` again, so double
+  formatting hides in a plain field; `RevisionInfo` pins `:revision` to the
+  client name `_rev`, and a second pass rewrites that to `rev`.
+
+  Every assertion goes through the three public pipeline stages a client's
+  response actually passes through — `execute_ash_action/1`,
+  `process_result/3`, `format_output_with_request/3` — never a private helper.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.AuditedRecord
+  alias AshIntrospection.Test.MetadataDomain
+
+  @show_metadata [:audit_entry, :revision_info, :raw_audit]
+
+  defp request(overrides) do
+    %{
+      domain: MetadataDomain,
+      resource: AuditedRecord,
+      rpc_action: %{},
+      input: %{},
+      context: %{},
+      select: [:id, :title],
+      load: [],
+      extraction_template: [:id, :title],
+      show_metadata: @show_metadata
+    }
+    |> Map.merge(overrides)
+    |> Request.new()
+  end
+
+  defp response(request) do
+    {:ok, ash_result} = Pipeline.execute_ash_action(request)
+    {:ok, processed} = Pipeline.process_result(ash_result, request)
+    Pipeline.format_output_with_request(%{success: true, data: processed}, request)
+  end
+
+  defp create_record(title) do
+    AuditedRecord
+    |> Ash.Changeset.for_create(:create, %{title: title})
+    |> Ash.create!()
+  end
+
+  defp read_response do
+    record = create_record("read-#{System.unique_integer([:positive])}")
+
+    request(%{
+      action: Ash.Resource.Info.action(AuditedRecord, :read_with_metadata),
+      get_by: %{id: record.id}
+    })
+    |> response()
+  end
+
+  describe "read action metadata" do
+    test "the nested keys of a typed map metadata value are camelized" do
+      %{"data" => data} = read_response()
+
+      assert %{"changedBy" => "ops-team", "changeReason" => "nightly cleanup"} ==
+               data["auditEntry"]
+    end
+
+    test "a client name pinned by the declared type survives the formatter" do
+      %{"data" => data} = read_response()
+
+      assert %{"_rev" => "rev-7", "revisedBy" => "ops-team"} == data["revisionInfo"]
+    end
+  end
+end

--- a/test/support/metadata_resources.ex
+++ b/test/support/metadata_resources.ex
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.RevisionInfo do
+  @moduledoc """
+  A typed map whose interop names are deliberately not camelCase.
+
+  `:revision` is exposed as `_rev`, a wire name a client pins rather than
+  derives. Running the camel-case formatter over `_rev` a second time rewrites
+  it to `rev`, which is the whole reason this type exists here: it turns a
+  double formatting pass from a silent no-op into an observable renaming. See
+  `test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs`.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        revision: [type: :string],
+        revised_by: [type: :string]
+      ]
+    ]
+
+  @doc "Field name mappings for interop (TypeScript, Kotlin, etc.)."
+  def interop_field_names do
+    [revision: "_rev", revised_by: "revisedBy"]
+  end
+end
+
+defmodule AshIntrospection.Test.MetadataDomain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource AshIntrospection.Test.AuditedRecord
+  end
+end
+
+defmodule AshIntrospection.Test.AuditedRecord do
+  @moduledoc """
+  Resource for exercising action metadata formatting on the read and the
+  mutation path.
+
+  It declares the three metadata shapes that format differently:
+
+  - `:audit_entry` is a typed map, so its nested keys are the library's to
+    camelize.
+  - `:revision_info` is a NewType carrying `interop_field_names/0`, so its
+    client names are pinned and must survive untouched.
+  - `:raw_audit` is an unconstrained `:map`, an explicit opt-out of typing, so
+    its keys belong to whoever wrote them and must reach the client verbatim.
+
+  `:raw_payload` is the same opt-out expressed as a generic action's return
+  type rather than as metadata.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.MetadataDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  @audit_entry %{changed_by: "ops-team", change_reason: "nightly cleanup"}
+  @revision_info %{revision: "rev-7", revised_by: "ops-team"}
+  @raw_audit %{
+    "_id" => "audit-1",
+    "field_name" => "title",
+    "nested" => %{"_rev" => "rev-7", "changed_by" => "ops-team"}
+  }
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, allow_nil?: false, public?: true
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+      accept [:title]
+    end
+
+    read :read_with_metadata do
+      get? true
+
+      metadata :audit_entry, :map,
+        constraints: [
+          fields: [
+            changed_by: [type: :string],
+            change_reason: [type: :string]
+          ]
+        ]
+
+      metadata :revision_info, AshIntrospection.Test.RevisionInfo
+      metadata :raw_audit, :map
+
+      prepare fn query, _context ->
+        Ash.Query.after_action(query, fn _query, records ->
+          {:ok, Enum.map(records, &AshIntrospection.Test.AuditedRecord.put_test_metadata/1)}
+        end)
+      end
+    end
+
+    create :create_with_metadata do
+      accept [:title]
+
+      metadata :audit_entry, :map,
+        constraints: [
+          fields: [
+            changed_by: [type: :string],
+            change_reason: [type: :string]
+          ]
+        ]
+
+      metadata :revision_info, AshIntrospection.Test.RevisionInfo
+      metadata :raw_audit, :map
+
+      change fn changeset, _context ->
+        Ash.Changeset.after_action(changeset, fn _changeset, record ->
+          {:ok, AshIntrospection.Test.AuditedRecord.put_test_metadata(record)}
+        end)
+      end
+    end
+
+    action :raw_payload, :map do
+      run fn _input, _context -> {:ok, AshIntrospection.Test.AuditedRecord.raw_audit()} end
+    end
+  end
+
+  @doc "The unconstrained map every action here hands back, keys and all."
+  def raw_audit, do: @raw_audit
+
+  @doc "Attaches the three metadata shapes this resource's actions declare."
+  def put_test_metadata(record) do
+    record
+    |> Ash.Resource.put_metadata(:audit_entry, @audit_entry)
+    |> Ash.Resource.put_metadata(:revision_info, @revision_info)
+    |> Ash.Resource.put_metadata(:raw_audit, @raw_audit)
+  end
+end


### PR DESCRIPTION
Closes #20.

Action metadata reached the client formatted wrongly in three different ways,
all in `lib/ash_introspection/rpc/pipeline.ex`. The cause is one thing: the
value was formatted in the wrong place, or twice, or by a formatter that had
no business touching it.

## What was wrong

| Path | Symptom | Upstream |
|---|---|---|
| Read | `%{changed_by: ...}` inside a typed-map metadata value reached the client in snake_case, wrapped in an otherwise camelCase response | `8a05642` |
| Mutation | The whole metadata map was camelized recursively, so a value already formatted by its type was formatted again | `9e5d05a` |
| Mutation | That same recursion renamed the keys inside an unconstrained `:map` — `_id` became `id`, `_rev` became `rev` | `919e817` |

A metadata name is not an attribute. Stage 4 looks it up on the resource,
finds nothing, and hands the value back untouched — which is why the read
path never formatted the nested keys at all, and why the mutation path had to
reach for a recursive formatter that knows no types.

## What changed

- Metadata values are formatted at extraction, by the type the action declared
  for them, through the same `ValueFormatter` dispatch attributes and
  calculations go through. That needs the action, so `add_read_metadata/3` and
  `add_mutation_metadata/3` become `/5`, threading `request.action` and the
  config into `extract_metadata_fields/4`.
- The response envelope formats the top-level metadata names and nothing
  below them.
- An unconstrained `:map` therefore passes through verbatim, because
  `ValueFormatter.format/5` has nothing to format it by. That is the point:
  declaring `:map` with no constraints is an opt-out of typing, and the keys
  the old code renamed — anything with a leading underscore — are exactly
  the wire names a client cannot reconstruct.
- `value_formatter_config/2` is extracted; `format_resource_output/4` and
  `format_generic_action_output/4` built the same map inline.

Generic actions returning an unconstrained map were already correct here
(`process_result/3` short-circuits them at `unconstrained_map_action?/1`).
That half of `919e817` is pinned by a test rather than fixed.

## Scope: the allowlist is not here

The other half of upstream's metadata fix is an allowlist on the *requested*
field list, and it lives in a parse stage this library does not have —
`parse_request/3` is in each language-specific wrapper. Nothing was built for
it here. `ash_kotlin_multiplatform` already has the check in `Rpc.Runner`
(`dsl_metadata_fields/2` reads the DSL allowlist, `narrow_metadata_fields/2`
intersects the client's request with it, so a client can only narrow). The
obligation is now written down in the "Action metadata" section of
`Rpc.Pipeline`'s `@moduledoc` and in `docs/decisions.md`.

## The guarantee is narrower than it looks — new risk T4

These fixes land on `format_output_with_request/3`, which has the request and
therefore the types. `format_output/2` has neither and still formats every key
it can reach.

**`ash_kotlin_multiplatform` calls `format_output/2`.**
`Runner.run_action/4` ends with `Pipeline.format_output(processed)`
(`lib/ash_kotlin_multiplatform/rpc/runner.ex:157`), so the consumer's
successful responses never see the typed path and its clients still get `_id`
rewritten to `id`. This is written up as risk T4 in `docs/risks.md`; the fix
is a one-line change in the consumer, which already builds the `%Request{}`
two lines earlier. Not done here.

## Test plan

Eight new tests in
`test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs`, all
driving the three public stages a client's response passes through —
`execute_ash_action/1`, `process_result/3`, `format_output_with_request/3` —
never a private helper. Four of them fail against `main`'s `pipeline.ex`
(verified by checking out `origin/main`'s copy of the file and re-running).

Detecting the double-formatting bug needed a name the formatter cannot
derive. `format_field_name/2` is idempotent for ordinary names — `changed_by`
becomes `changedBy` and stays there, and so do `_id`, `field_1_name` and
`v2_token` — so a casing assertion passes against both the buggy and the
fixed code. The new fixture `AshIntrospection.Test.RevisionInfo` pins
`:revision` to the client name `_rev` via `interop_field_names/0`; a second
camelization rewrites that to `rev`, which a test can see. That lesson is now
in `CLAUDE.md`.

New fixtures live in a new file, `test/support/metadata_resources.ex`
(`RevisionInfo`, `MetadataDomain`, `AuditedRecord`). No shared fixture was
modified — #55 is restructuring ETS ownership across the suite in parallel.
The new test file is `async: true` and calls no `Ash.DataLayer.Ets.stop/1`.

```
mix format --check-formatted   ok
mix compile --warnings-as-errors   ok
mix test                       309 tests, 0 failures
mix hex.audit                  No retired packages found
mix deps.audit                 No vulnerabilities found
```

301 → 309 tests.

**Known flake, not this change.** 3 of my 21 full-suite runs failed on the
shared `Test.Account` ETS table (#55) — `PipelineFilterInjectionTest` and
`PipelineIdentityBooleanTest`, with `the table identifier does not refer to an
existing ETS table` or its `record with id: "..." not found` symptom. That
rate matches the ~1-in-12 measured on `main` in `CLAUDE.md`. Re-run if CI
trips on it.

## Docs

- `docs/roadmap.md` — #20 moved to Shipped, and dropped from the list of
  issues #23 blocks.
- `docs/decisions.md` — two entries: the formatting rule, and the allowlist
  boundary.
- `docs/risks.md` — T4 above; test count 301 → 309 in T3.
- `docs/PROJECT.md` — hub counts.
- `CHANGELOG.md` — three entries under Unreleased/Fixed.
- `CLAUDE.md` — the idempotence lesson, and test count 281 → 309.

`docs/roadmap.md` and `CLAUDE.md` are also being edited on the #55 branch;
these entries are additive and should merge rather than replace.
