### PR TITLE
test: fix the ETS flake by giving Test.Account a private table (#55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,34 +139,43 @@ camelCase changes under a second pass: `AshIntrospection.Test.RevisionInfo`
 maps `:revision` to `_rev`, which a second camelization rewrites to `rev`. See
 `test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs`.
 
-### The `Test.Account` suite flakes on a torn-down ETS table
+### Never call `Ash.DataLayer.Ets.stop/1` in a test — fixed in #55
 
-**Symptom.** Roughly one full `mix test` run in twelve fails on `main` with no
-source change, always in a file that writes `AshIntrospection.Test.Account`:
-`PipelineFilterInjectionTest`, `PipelineIdentityOnReadTest`,
-`PipelineIdentityBooleanTest` or `ValueFormatterVectorTest`. The message is
-either `record with id: "..." not found` or, uncovered, the real one:
+**Symptom, before the fix.** Roughly one `mix test` run in forty failed on
+`main` with no source change, always in a file that writes
+`AshIntrospection.Test.Account`. The message was either `record with id: "..."
+not found` or the real one:
 
 ```
 ** (ArgumentError) errors were found at the given arguments:
   * 1st argument: the table identifier does not refer to an existing ETS table
 ```
 
-Measured 2026-09-09 at `91ecead`: 7 failures in 87 consecutive runs of the
-untouched suite. **It is not your change.** Re-run before you start bisecting.
+**Why.** Five test files called `Ash.DataLayer.Ets.stop(Account)` from
+`on_exit`. Without `private?`, the Ets data layer keeps one named table per
+resource for the whole VM, owned by a `TableManager` GenServer, and `stop/1`
+only sends it `Process.exit(pid, :shutdown)` before returning
+(`deps/ash/lib/ash/data_layer/ets/ets.ex:180`). The kill is asynchronous, so
+the next test's `setup` could reach `TableManager.start/3`, wrap the table the
+VM had not yet reaped, and write to a dead reference. The race is **inside one
+file**, between one test's `on_exit` and the next test's `setup` — not across
+files, and `async: false` does not prevent it.
 
-**Why.** Five test files call `Ash.DataLayer.Ets.stop(Account)` from `on_exit`
-(`pipeline_filter_injection_test.exs:21`,
-`pipeline_identity_on_read_test.exs:23`, `value_formatter_vector_test.exs:29`,
-`pipeline_identity_boolean_test.exs:31`,
-`error_builder_bulk_errors_test.exs:29`). There is one ETS table per resource
-for the whole VM, so that teardown is global. Every one of those files is
-`async: false`, so the ordering that breaks it has not been pinned down — the
-table reference a test holds simply stops existing under it.
+**The measurement.** Both figures are 200 consecutive runs on this machine, at
+`f43a4ea`: the full suite failed 5 times before the fix and 0 after, and
+`pipeline_filter_injection_test.exs` run alone failed 11 times before and 0
+after. `--seed` does not pin it: seed `850929` failed once in 30 runs of that
+file, the same rate as any other seed. It is a timing race, so a failing seed
+is not a repro — a loop is.
 
-**What we do.** Nothing yet; no ticket owns it. Do not add a sixth
-`Ash.DataLayer.Ets.stop/1`, and do not claim a green suite from one run — run
-`mix test` a few times before calling a change clean.
+**What we do.** `test/support/rpc_resources.ex` declares `ets do private?(true)
+end` on `Account`, so every test process gets its own unnamed table that the VM
+reaps when the process exits. There is nothing to tear down: **do not add an
+`Ash.DataLayer.Ets.stop/1` call anywhere.** The one thing a private table
+forbids is writing the resource from another process — a `Task`, a spawned
+process, or a `setup_all` block sees an empty table, because the table lives in
+the creating process's dictionary. Keep writes in the test process. If a new
+test resource needs writing, give it `private? true` at birth.
 
 ### No stdlib `JSON`: `mix.exs` declares `elixir: "~> 1.15"`
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -60,6 +60,30 @@ exactly the wire names a client cannot reconstruct.
 holds on `format_output_with_request/3`, which has the types, and not on
 `format_output/2`, which does not — and `format_output/2` is what
 `ash_kotlin_multiplatform` calls. See risk T4 in [risks.md](risks.md).
+## 2026-09-09 — The writable test resource gets a private ETS table
+
+**Decided.** `AshIntrospection.Test.Account` declares `ets do private?(true)
+end`, and the five test files that write to it no longer call
+`Ash.DataLayer.Ets.stop/1` from `on_exit`. Issue #55.
+
+**Why.** Without `private?`, the Ets data layer keeps one named table for the
+whole VM behind a `TableManager` GenServer, so the only way to empty it between
+tests was `stop/1` — which sends that GenServer `Process.exit(pid, :shutdown)`
+and returns. The kill is asynchronous, so the next test's `setup` could wrap
+the table before the VM reaped it and then write to a dead reference. `mix
+test` failed 5 times in 200 runs on `main`; the file that carried most of it,
+`pipeline_filter_injection_test.exs`, failed 11 times in 200 runs of that one
+file alone. `private?` moves the isolation into the data layer: each test
+process gets its own unnamed table, reaped when the process exits, so there is
+nothing left to tear down and nothing shared to race on.
+
+**Cost.** A private table is visible only to the process that created it. A
+test that writes `Account` from a spawned process, a `Task`, or a `setup_all`
+block will see an empty table rather than the records it just wrote. That is
+the trade for the isolation, and it is recorded in [`CLAUDE.md`](../CLAUDE.md).
+It also turns off the Ash async engine for this resource
+(`Ash.DataLayer.Ets.can?/2` answers `false` for `:async_engine` when
+`private?`), which nothing here depends on.
 
 ## 2026-09-09 — `identity` is an update/destroy key; reads reject it
 

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -96,6 +96,16 @@ runs the suite on every pull request as of #32.
 **What we would do.** Keep landing a regression test with each fix, per #18's
 own preference, and treat a fix that arrives without one as unfinished.
 
+**The suite no longer flakes, and that is new.** Until #55, `mix test` failed
+about 1 run in 40 on an unchanged `main` because five test files tore down a
+VM-wide ETS table from `on_exit`. A flaky gate teaches reviewers to re-run
+rather than read, which costs more than the flake.
+`AshIntrospection.Test.Account` is now `private? true`, so isolation is a
+property of the data layer. The replacement risk is smaller and stated here so
+it is not rediscovered: a private ETS table belongs to the process that created
+it, so a test that writes `Account` from a `Task` or a `setup_all` block will
+read an empty table instead of failing loudly. Keep writes in the test process.
+
 ### T4 — Two stage-4 exits, and the consumer uses the untyped one
 
 **The risk.** `Rpc.Pipeline` exposes two stage-4 functions.
@@ -126,7 +136,6 @@ already builds the `%Request{}` two lines earlier, so the change is one line
 plus its tests. That is a ticket in `ash_kotlin_multiplatform`, not here.
 Collapsing the two functions into one is the larger answer and needs the
 error-response path, which legitimately has no request, to keep working.
-
 ## Operational
 
 ### O1 — Security drift in the dependency floor

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,15 @@ which come first. Numbers in parentheses are GitHub issues on
   The allowlist half of upstream's metadata fix belongs to a parse stage this
   library does not have; see [decisions.md](decisions.md) and risk T4 in
   [risks.md](risks.md).
+- **Stop the suite flaking on a torn-down ETS table** (#55).
+  `AshIntrospection.Test.Account` now declares `private? true`, so each test
+  process gets its own unnamed ETS table instead of sharing one named table for
+  the whole VM. The five `Ash.DataLayer.Ets.stop/1` calls in `on_exit` are gone
+  with it: `stop/1` kills the table's owning GenServer asynchronously, and the
+  next test could wrap the table before the VM reaped it. Measured on the
+  branch: `mix test` failed 5 times in 200 runs before the change and 0 times
+  in 200 runs after; `pipeline_filter_injection_test.exs` alone went from 11
+  failures in 200 runs to 0. See [decisions.md](decisions.md).
 - **Guard every consumer-module callback check with `Code.ensure_loaded?/1`**
   (#49). `function_exported?/3` answers `false` for a module the VM has not
   loaded, and Elixir loads lazily, so a domain, resource or type nothing had

--- a/test/ash_introspection/rpc/error_builder_bulk_errors_test.exs
+++ b/test/ash_introspection/rpc/error_builder_bulk_errors_test.exs
@@ -26,8 +26,6 @@ defmodule AshIntrospection.Rpc.ErrorBuilderBulkErrorsTest do
   alias AshIntrospection.Test.RpcDomain
 
   setup do
-    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
-
     suffix = System.unique_integer([:positive])
 
     account =

--- a/test/ash_introspection/rpc/pipeline_filter_injection_test.exs
+++ b/test/ash_introspection/rpc/pipeline_filter_injection_test.exs
@@ -18,8 +18,6 @@ defmodule AshIntrospection.Rpc.PipelineFilterInjectionTest do
   alias AshIntrospection.Test.RpcDomain
 
   setup do
-    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
-
     suffix = System.unique_integer([:positive])
 
     alice =

--- a/test/ash_introspection/rpc/pipeline_identity_boolean_test.exs
+++ b/test/ash_introspection/rpc/pipeline_identity_boolean_test.exs
@@ -28,8 +28,6 @@ defmodule AshIntrospection.Rpc.PipelineIdentityBooleanTest do
   alias AshIntrospection.Test.RpcDomain
 
   setup do
-    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
-
     suffix = System.unique_integer([:positive])
     name = "Shared-#{suffix}"
 

--- a/test/ash_introspection/rpc/pipeline_identity_on_read_test.exs
+++ b/test/ash_introspection/rpc/pipeline_identity_on_read_test.exs
@@ -20,8 +20,6 @@ defmodule AshIntrospection.Rpc.PipelineIdentityOnReadTest do
   alias AshIntrospection.Test.RpcDomain
 
   setup do
-    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
-
     suffix = System.unique_integer([:positive])
 
     alice =

--- a/test/ash_introspection/rpc/value_formatter_vector_test.exs
+++ b/test/ash_introspection/rpc/value_formatter_vector_test.exs
@@ -26,8 +26,6 @@ defmodule AshIntrospection.Rpc.ValueFormatterVectorTest do
   @embedding [0.5, -1.5, 2.25]
 
   setup do
-    on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)
-
     suffix = System.unique_integer([:positive])
 
     account =

--- a/test/support/rpc_resources.ex
+++ b/test/support/rpc_resources.ex
@@ -26,10 +26,24 @@ defmodule AshIntrospection.Test.Account do
   `:embedding` is an `Ash.Type.Vector`, whose `%Ash.Vector{}` keeps its floats
   in a packed binary that JSON cannot encode. It is here so the output path can
   be driven end to end against a real vector attribute.
+
+  This is the only test resource anything writes to, and five test files write
+  to it. `private? true` gives each *test process* its own unnamed ETS table
+  (`Ash.DataLayer.Ets.wrap_or_create_table/3` keys it off the process
+  dictionary, `deps/ash/lib/ash/data_layer/ets/ets.ex:2257`), which the VM
+  reaps when the process exits. Without it there is one named table for the
+  whole VM, guarded by a `TableManager` GenServer, and the only way to empty it
+  between tests is `Ash.DataLayer.Ets.stop/1` — which kills that GenServer
+  asynchronously and lets the next test wrap a table that is already doomed.
+  See #55.
   """
   use Ash.Resource,
     domain: AshIntrospection.Test.RpcDomain,
     data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private?(true)
+  end
 
   attributes do
     uuid_primary_key(:id)


### PR DESCRIPTION
`mix test` failed on an unchanged `main` with `the table identifier does not
refer to an existing ETS table`, always in a file writing
`AshIntrospection.Test.Account`. This gives that resource a private ETS table
per test process and deletes the five `Ash.DataLayer.Ets.stop/1` teardowns that
caused it.

Closes #55.

## The measurement

Same loop, same iteration count, both sides. One `mix test` run takes ~1s here,
so 200 runs is ~4 minutes.

| Loop | Before | After |
|---|---|---|
| `mix test` × 200 | **5 failures** | **0 failures** |
| `mix test test/ash_introspection/rpc/pipeline_filter_injection_test.exs` × 200 | **11 failures** | **0 failures** |

The "after" numbers were taken twice — once on the fix alone, once again after
rebasing onto `main` with #20 merged (309 tests). 800 post-fix runs in total, 0
failures.

The baseline rate here is 1 run in 40, not the 1 in 12 recorded in the issue.
Same bug, quieter machine.

## The repro

**There is no deterministic seed, and `--seed` is not the tool.** Seed `850929`
failed once in 30 runs of the same file — the same rate as any other seed. The
race is timing, not ordering, so a failing seed is not a repro. A loop is:

```sh
for i in $(seq 1 200); do
  mix test test/ash_introspection/rpc/pipeline_filter_injection_test.exs \
    > /tmp/run-$i.log 2>&1 || echo "FAILED $i"
done
```

That is the cheapest repro found: **one file, 9 tests, no other module
involved**, failing 11 times in 200 runs.

## What actually interleaves

The issue's cause class — one file's teardown dropping a table another file is
still using, under `async: true` — is not what happens. All five files are
`async: false`, and the flake reproduces with a single file running alone.

The race is **inside one file**, between one test's `on_exit` and the next
test's `setup`:

```mermaid
sequenceDiagram
    participant T1 as test N (process)
    participant OE as on_exit (process)
    participant TM as Account.TableManager
    participant VM as BEAM / ETS
    participant T2 as test N+1 (process)

    T1->>TM: Ash.create!/1 → wrap_or_create_table
    TM->>VM: named public table :"...Test.Account"
    Note over T1: test N passes
    OE->>TM: Ash.DataLayer.Ets.stop(Account)
    Note over OE,TM: Process.exit(pid, :shutdown) — returns immediately
    OE-->>T2: on_exit done, runner starts the next test
    T2->>TM: Ash.create!/1 → TableManager.start/3
    Note over T2,TM: manager still registered, or table not yet reaped
    TM-->>T2: ETS.Set.wrap_existing/1 → #Reference<...>
    VM--xVM: doomed owner terminates, table deleted
    T2->>VM: :ets.insert_new(#Reference<...>, record)
    VM-->>T2: ArgumentError — no such table
```

`Ash.DataLayer.Ets.stop/1` sends the owning GenServer
`Process.exit(pid, :shutdown)` and returns
(`deps/ash/lib/ash/data_layer/ets/ets.ex:180`). Nothing waits for it to die.
The next `setup` then reaches `TableManager.start/3`, which either gets
`{:error, {:already_started, dying_pid}}` and wraps the table anyway, or starts
a fresh manager whose `wrap_existing/1` finds the table the VM has not reaped
yet (`ets.ex:97-107`). Either way the caller holds a reference to a table that
is about to disappear.

Both observed symptoms come from that one window. Write first, table dies
second → `the table identifier does not refer to an existing ETS table`. Table
dies first, empty one takes its place → `record with id: "..." not found`.

Straight from a failing log, and note the frame — it is the module's own
`setup`, not another file:

```
1) test identity lookups on update an exact scalar identity still updates the named record
   (AshIntrospection.Rpc.PipelineFilterInjectionTest)
   ** (ArgumentError) errors were found at the given arguments:
     * 1st argument: the table identifier does not refer to an existing ETS table
   (stdlib) :ets.insert_new(#Reference<0.913368731.81395715.50624>, ...)
   (ash 3.33.1) lib/ash/data_layer/ets/ets.ex:1783: Ash.DataLayer.Ets.put_or_insert_new/3
   test/ash_introspection/rpc/pipeline_filter_injection_test.exs:28:
     AshIntrospection.Rpc.PipelineFilterInjectionTest.__ex_unit_setup_0/1
```

## The fix

`AshIntrospection.Test.Account` declares:

```elixir
ets do
  private?(true)
end
```

Each test **process** then gets its own unnamed ETS table, keyed off the
process dictionary (`ets.ex:2257`) and reaped by the VM when the process exits.
No named table, no `TableManager`, nothing shared, nothing to tear down — so
the five `on_exit(fn -> Ash.DataLayer.Ets.stop(Account) end)` calls are gone.

This is option 1 from the issue. Nothing was marked `async: false` (all five
already were, and it was never the fix), no retry, no sleep, no test weakened
or deleted. `Account` is the only test resource anything writes to, so it is
the only one that needed it.

**What the fix costs.** A private table is visible only to the process that
created it. A future test that writes `Account` from a `Task`, a spawned
process or a `setup_all` block will read an empty table rather than fail
loudly. Writes must stay in the test process. That is recorded in `CLAUDE.md`
and `docs/decisions.md`.

## Test plan

- `mix format --check-formatted` — clean.
- `mix compile --force --warnings-as-errors` — clean.
- `mix test` — **309 tests, 0 failures** (count unchanged by this PR; #20
  raised it from 301).
- `mix hex.audit` — no retired packages. `mix deps.audit` — no
  vulnerabilities.
- The two loops above, 200 runs each, before and after.

## Documentation

- `CLAUDE.md` — the flake lesson told a future session to expect the flake and
  re-run. It now says what the fix was, both measurements, that the race is
  intra-file rather than cross-file, and the one thing a private table forbids.
- `docs/roadmap.md` — #55 under Shipped → Unreleased, merged with #20's entry.
- `docs/decisions.md` — dated entry with the cost.
- `docs/risks.md` — T3 gains the retirement of the flake and names the smaller
  risk that replaces it.

No `CHANGELOG.md` entry: the change is test-only and nothing a consumer of the
library can observe changes.
