### PR TITLE
feat: shape an action's loadable surface with allowed_loads / denied_loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `AshIntrospection.Rpc.LoadRestrictions`, and an optional `:load_restrictions`
+  key on the field-selection config map
+  ([#19](https://github.com/udin-io/ash_introspection/issues/19)). It takes
+  `{:allow, spec}` or `{:deny, spec}`, where `spec` nests internal field names
+  (`[comments: [:score]]`), and shapes which relationships, calculations and
+  aggregates an action will load.
+  `AshIntrospection.Rpc.FieldProcessing.FieldSelector` checks it at all six
+  points where it appends to the Ash load statement, so a nested path is
+  checked at every level. Omitting the key permits every load, so no consumer
+  has to act. A refused load answers `load_not_allowed` or `load_denied`,
+  naming the dotted path. **This is an API surface control, not
+  authorization** — Ash policies apply to every load that gets through.
+
 ### Changed
 
 - **Breaking.** A read action carrying `identity` is rejected with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,41 @@ process, or a `setup_all` block sees an empty table, because the table lives in
 the creating process's dictionary. Keep writes in the test process. If a new
 test resource needs writing, give it `private? true` at birth.
 
+### A new load in `FieldSelector` needs a `check_load_allowed!/3`
+
+**Symptom.** A load restriction that works for every other field is silently
+ignored for the one you just added, and no test fails.
+
+**Why.** `AshIntrospection.Rpc.LoadRestrictions` is enforced at the six points
+where `Rpc.FieldProcessing.FieldSelector` appends to the Ash load statement,
+not by walking the finished load statement. That is deliberate — a separate
+traversal has to re-derive which parts of a load list are loads and which are
+selects, and upstream's did it wrong (`ash_typescript` `3aaae6b`). The price is
+that a seventh append site added later is unguarded by default and nothing says
+so.
+
+**What we do.** Check that every hit of this grep has a
+`check_load_allowed!(path, internal_name, config)` above it:
+
+```
+grep -n 'load ++ \|load_acc ++' \
+  lib/ash_introspection/rpc/field_processing/field_selector.ex
+```
+
+#24 (relationship query envelopes) adds one: a relationship loaded through an
+`%Ash.Query{}` envelope.
+
+**Two of the six cannot be made to refuse.** The embedded-attribute and
+union-member sites only fire when a nested selection already produced a load,
+and that nested load passed the check one level deeper; a passing child implies
+a passing parent under both `:allow` and `:deny`. Do not write a test that
+claims otherwise, and do not delete the guards — see the comments at those
+sites. See `test/ash_introspection/rpc/load_restrictions_test.exs`.
+
+**They are not authorization.** Ash policies apply to every load that gets
+through. Say so in anything you write about them; risk T5 in
+[`docs/risks.md`](docs/risks.md) explains why it matters.
+
 ### No stdlib `JSON`: `mix.exs` declares `elixir: "~> 1.15"`
 
 **Symptom.** Code using the `JSON` module compiles on your machine and fails on

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ release breaks.
 | `AshIntrospection.Rpc.FieldProcessing.Atomizer` | Convert client field names to atoms |
 | `AshIntrospection.Rpc.FieldProcessing.FieldSelector` | Type-driven recursive field selection |
 | `AshIntrospection.Rpc.FieldProcessing.Validation` | Duplicate detection and field validation |
+| `AshIntrospection.Rpc.LoadRestrictions` | Shapes which loads an action will accept |
 
 ### Error Handling
 
@@ -233,6 +234,32 @@ config = %{
   end
 }
 ```
+
+### Load Restrictions
+
+An optional `:load_restrictions` key on the config map shapes which
+relationships, calculations and aggregates an action will load. Omit it and
+every load is permitted, which is the default.
+
+```elixir
+# comments may be loaded, but not comments.score
+config = %{load_restrictions: {:deny, [comments: [:score]]}}
+
+# only comments and comments.score may be loaded
+config = %{load_restrictions: {:allow, [comments: [:score]]}}
+```
+
+A deny inherits downwards: denying `comments` denies everything under it. An
+allow does not: allowing `comments` does not allow `comments.score`, but naming
+`comments.score` allows `comments` as the step needed to reach it. Attributes
+are selected rather than loaded and are never restricted.
+
+**This is not authorization.** Load restrictions keep an expensive load off an
+endpoint that has no need for it. They say nothing about who may see a value —
+Ash policies and field policies do that, and they apply to every load that gets
+through. A field that must be hidden from an actor needs a policy; a deny list
+leaves it readable through every other action. See
+`AshIntrospection.Rpc.LoadRestrictions`.
 
 ## Field Name Mapping
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,6 +108,7 @@ flowchart LR
 
     subgraph internal["ash_introspection: reached through the pipeline"]
         fsel["Rpc.FieldProcessing.FieldSelector"]
+        lrest["Rpc.LoadRestrictions"]
         atomz["Rpc.FieldProcessing.Atomizer"]
         fval["Rpc.FieldProcessing.Validation"]
         rproc["Rpc.ResultProcessor"]
@@ -140,6 +141,7 @@ flowchart LR
     pipeline --> efmt
     pipeline --> tsi
     pipeline --> ash
+    fsel -->|"one load path per append"| lrest
     fsel --> atomz
     fsel --> fval
     fsel --> rfields
@@ -182,6 +184,7 @@ sequenceDiagram
     P->>K: params, actor, tenant
     Note over K: Stage 1 is language-specific<br/>and lives in the consumer
     K->>F: process(fields, resource, action, config)
+    Note over F: each append to the load statement<br/>passes Rpc.LoadRestrictions.check!/2<br/>when config carries :load_restrictions
     F-->>K: {select, load, extraction_template}
     K->>S: execute_ash_action(%Request{}, config)
     S->>A: Ash.read / create / update / destroy / run_action

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,6 +13,39 @@ recorded nowhere in the repo. This page replaces ADRs; there is no `adr/`
 directory here and none should be created. A decision that no longer shapes the
 code is deleted, not archived, because git keeps the history.
 
+## 2026-09-09 — Load restrictions ride on the config map, not a manifest
+
+**Decided.** `allowed_loads` / `denied_loads` reach field selection through an
+optional `:load_restrictions` key on the config map that
+`FieldSelector.process/4` already takes, the same shape `:is_interop_resource?`
+and `get_rpc_action_entrypoints` use. Upstream `ash_typescript` reads them from
+`Ash.Info.Manifest` instead. Issue #19.
+
+**Why.** This library has not adopted the manifest and will not for a while
+(#23, below). Waiting for it would have left every generator built on this core
+unable to shape an action's loadable surface, which is why
+`ash_kotlin_multiplatform` shipped without the feature. The config map is
+already threaded to every point that appends to the load statement, so the
+value arrives where the check happens with no new plumbing, and omitting the
+key means `:none`, so no existing caller changes behaviour.
+
+**Also decided:** restrictions are checked **during** field selection, at each
+of the six points where `FieldSelector` appends to the load statement, rather
+than by walking the finished load statement. A separate traversal has to
+re-derive which parts of a load list are loads and which are selects, and
+upstream's did: nested scalar loads escaped it entirely until `3aaae6b`. A
+check at the append site cannot disagree with field selection about what is
+being loaded, because it is field selection.
+
+**Cost.** A second place restrictions can come from once #23 lands, and someone
+will have to decide whether the manifest supersedes the config key or feeds it.
+The config key is also unvalidated: a typo in a field name is a path that
+matches nothing, which under `{:deny, ...}` silently restricts nothing. A
+manifest-backed DSL would catch that at compile time. And this is an API
+surface tool, not authorization — Ash policies still apply to every load that
+gets through, which the moduledoc says plainly because the failure mode of
+believing otherwise is a security hole.
+
 ## 2026-09-09 — The metadata allowlist stays with the caller
 
 **Decided.** This pipeline extracts exactly the metadata fields

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -136,6 +136,32 @@ already builds the `%Request{}` two lines earlier, so the change is one line
 plus its tests. That is a ticket in `ash_kotlin_multiplatform`, not here.
 Collapsing the two functions into one is the larger answer and needs the
 error-response path, which legitimately has no request, to keep working.
+
+### T5 — Load restrictions read as a security control
+
+**The risk.** `allowed_loads` / `denied_loads` (#19) shape which relationships,
+calculations and aggregates a client may ask an action for. They look exactly
+like an access-control list, and the next person to need "hide this field from
+this caller" will reach for them. They are not that. Ash policies, field
+policies and tenancy are what decide who may see a value, and they apply to
+every load that passes a restriction.
+
+**Why it bites.** A field denied on one action stays readable through every
+other action and through any caller that is not this pipeline — a codegen
+consumer, a LiveView, a script. Someone who believes the deny list is the
+boundary ships a resource with no policy on it and no error to tell them.
+
+**What we watch.** Every mention of load restrictions in a moduledoc, a doc
+page or an error message says what they are for, which is cost: keeping an
+expensive load off an endpoint that has no need for it. The moduledoc on
+`AshIntrospection.Rpc.LoadRestrictions` says it first and says it plainly.
+Upstream `ash_typescript` draws the same line in `24266dc`.
+
+**What we would do.** If a consumer is found using a deny list where a policy
+belongs, the fix is the policy; the restriction stays as the surface control it
+is. If the confusion recurs, rename the config key to something that cannot be
+read as authorization.
+
 ## Operational
 
 ### O1 — Security drift in the dependency floor

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,18 @@ which come first. Numbers in parentheses are GitHub issues on
 
 ### Unreleased
 
+- **Shape an action's loadable surface with `allowed_loads` / `denied_loads`**
+  (#19). The core could not restrict what a client loads, so no generator
+  built on it could either, and `ash_kotlin_multiplatform` shipped without the
+  feature. `AshIntrospection.Rpc.LoadRestrictions` now carries the algebra and
+  `FieldSelector` calls `check!/2` at all six points where it appends to the
+  Ash load statement, so a nested path is checked at every level rather than
+  re-derived from a finished load statement. Restrictions arrive on the config
+  map under an optional `:load_restrictions` key, not from
+  `Ash.Info.Manifest`, which this repo has not adopted (#23) — see
+  [decisions.md](decisions.md). Omitting the key changes nothing for existing
+  callers. Ports `ash_typescript` `3aaae6b`, and keeps its framing from
+  `24266dc`: this shapes an API surface, it is not authorization.
 - **Format action metadata once, and by its declared type** (#20). A metadata
   name is not an attribute, so stage 4 looked it up on the resource, found
   nothing, and handed the value back untouched: the nested keys of a typed-map
@@ -116,7 +128,7 @@ dozen other items.
 1. **#23 — adopt `Ash.Info.Manifest`.** Upstream replaced live introspection
    with a precomputed Spark manifest in `ash` 3.32.3. This repo still calls
    `Ash.Resource.Info` at ~66 sites, which is why upstream's type-discovery
-   fixes do not port cleanly. Blocks #19, #24, #25, #26 and more, and
+   fixes do not port cleanly. Blocks #24, #25, #26 and more, and
    carries the remainder of #21: entrypoint scoping here branches on the action
    kind, where upstream's `Reachability` walks the accepted attributes, loads
    and relationship depth of each declared action.
@@ -127,9 +139,12 @@ dozen other items.
    serialize `Ash.Type.Vector`).
 3. **#18 — the RPC test floor.** Coverage arrives with each fix by preference,
    but the harness and the fixtures are still a ticket of their own.
-4. **Upstream parity features**: #19 (load restrictions), #24 (relationship
-   query envelopes), #25 (calculation load-through and nested first-aggregates),
-   #26 (persist formatted field names via a Spark transformer).
+4. **Upstream parity features**: #24 (relationship query envelopes), #25
+   (calculation load-through and nested first-aggregates), #26 (persist
+   formatted field names via a Spark transformer). #24 touches the same
+   `FieldSelector` clauses #19 just guarded: a relationship loaded through an
+   `%Ash.Query{}` envelope is a seventh append site and needs its own
+   `check_load_allowed!/3`.
 5. **Housekeeping**: #27 (dead code and a wrong pipeline moduledoc), #45 (the
    remaining `||` key-lookup pattern in `field_selector`), #39 (README wrapping
    — half of it, the test-domain warning, is already fixed in

--- a/lib/ash_introspection/rpc/error_builder.ex
+++ b/lib/ash_introspection/rpc/error_builder.ex
@@ -483,6 +483,42 @@ defmodule AshIntrospection.Rpc.ErrorBuilder do
           }
         }
 
+      # === LOAD RESTRICTION ERRORS ===
+      # Thrown by AshIntrospection.Rpc.LoadRestrictions during field selection.
+      # These shape an action's API surface; they are not authorization, which
+      # Ash policies handle independently of anything here.
+
+      {:load_not_allowed, disallowed_paths} ->
+        %{
+          type: "load_not_allowed",
+          message: "Loading the following fields is not allowed: %{fields}",
+          short_message: "Load not allowed",
+          vars: %{fields: Enum.join(disallowed_paths, ", ")},
+          path: [],
+          fields: disallowed_paths,
+          details: %{
+            disallowed_paths: disallowed_paths,
+            suggestion:
+              "Remove these fields from your request, or add them to the action's allowed loads",
+            hint: @stale_generated_file_hint
+          }
+        }
+
+      {:load_denied, denied_paths} ->
+        %{
+          type: "load_denied",
+          message: "Loading the following fields is denied: %{fields}",
+          short_message: "Load denied",
+          vars: %{fields: Enum.join(denied_paths, ", ")},
+          path: [],
+          fields: denied_paths,
+          details: %{
+            denied_paths: denied_paths,
+            suggestion: "Remove these fields from your request",
+            hint: @stale_generated_file_hint
+          }
+        }
+
       {:invalid_input_format, invalid_input} ->
         %{
           type: "invalid_input_format",

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -34,6 +34,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
 
   alias AshIntrospection.FieldFormatter
   alias AshIntrospection.Rpc.FieldProcessing.Validation
+  alias AshIntrospection.Rpc.LoadRestrictions
   alias AshIntrospection.TypeSystem.Introspection
 
   @type select_result :: {select :: [atom()], load :: [term()], template :: [term()]}
@@ -43,7 +44,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
           optional(:field_names_callback) => atom(),
           optional(:resource_info_module) => module(),
           optional(:is_interop_resource?) => (module() -> boolean()),
-          optional(:get_original_field_name) => (module(), term() -> atom() | nil)
+          optional(:get_original_field_name) => (module(), term() -> atom() | nil),
+          optional(:load_restrictions) => term()
         }
 
   # ---------------------------------------------------------------------------
@@ -60,7 +62,10 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   - `resource` - The Ash resource module
   - `action_name` - The action name (atom)
   - `requested_fields` - List of field selections (atoms, strings, or maps)
-  - `config` - Language-specific configuration
+  - `config` - Language-specific configuration. An optional
+    `:load_restrictions` key shapes which relationships, calculations and
+    aggregates the caller may ask for - see
+    `AshIntrospection.Rpc.LoadRestrictions`. Omitting it permits every load.
 
   ## Examples
 
@@ -74,6 +79,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
     if is_nil(action) do
       throw({:action_not_found, action_name})
     end
+
+    config = normalize_load_restrictions(config)
 
     {type, constraints} = action_to_type_spec(resource, action)
     {select, load, template} = select_fields(type, constraints, requested_fields, [], config)
@@ -123,6 +130,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   """
   @spec select_fields(atom() | tuple(), keyword(), list(), list(), config()) :: select_result()
   def select_fields(type, constraints, requested_fields, path, config) do
+    config = normalize_load_restrictions(config)
     field_names_callback = Map.get(config, :field_names_callback, :interop_field_names)
 
     {unwrapped_type, full_constraints} =
@@ -269,6 +277,7 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
         throw({:requires_field_selection, :relationship, internal_name, path})
 
       cat when cat in [:calculation, :aggregate] ->
+        check_load_allowed!(path, internal_name, config)
         {select, load ++ [internal_name], template ++ [internal_name]}
     end
   end
@@ -332,6 +341,13 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
            ] ->
         new_load =
           if nested_load != [] do
+            # No test reaches a refusal here, and none can: a non-empty
+            # nested_load means a deeper path already passed check!/2, and a
+            # passing child implies a passing parent under both :allow and
+            # :deny. The guard stays because the invariant it rests on belongs
+            # to the whole descent, not to this clause - it is the one thing
+            # that would still hold if a future append site forgot its check.
+            check_load_allowed!(path, internal_name, config)
             load ++ [{internal_name, nested_load}]
           else
             load
@@ -347,10 +363,12 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
           throw({:unknown_field, internal_name, resource, path})
         end
 
+        check_load_allowed!(path, internal_name, config)
         load_spec = build_load_spec(internal_name, nested_select, nested_load)
         {select, load ++ [load_spec], template ++ [{internal_name, nested_template}]}
 
       cat when cat in [:calculation, :calculation_complex] ->
+        check_load_allowed!(path, internal_name, config)
         load_spec = build_load_spec(internal_name, nested_select, nested_load)
         {select, load ++ [load_spec], template ++ [{internal_name, nested_template}]}
 
@@ -442,6 +460,8 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       else
         {internal_name, nested_template}
       end
+
+    check_load_allowed!(path, internal_name, config)
 
     {select, load ++ [load_spec], template ++ [template_item]}
   end
@@ -886,6 +906,10 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
       )
 
     if nested_load != [] do
+      # Unobservable for the same reason as the embedded branch of
+      # process_nested_resource_field/6; see the note there.
+      check_load_allowed!(path, internal_name, config)
+
       {load_acc ++ [{internal_name, nested_load}],
        template_acc ++ [{member_name, nested_template}]}
     else
@@ -1162,6 +1186,24 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
   defp has_field_names_callback?(module, config) do
     callback = Map.get(config, :field_names_callback, :interop_field_names)
     Introspection.has_field_names_callback?(module, callback)
+  end
+
+  # Called wherever this module appends to the Ash load statement, which is the
+  # only way a load can reach it: a restriction therefore cannot be sidestepped
+  # by a load shape the check does not know about. Attributes are selected
+  # rather than loaded and are deliberately not checked here.
+  defp check_load_allowed!(path, internal_name, config) do
+    LoadRestrictions.check!(path ++ [internal_name], Map.get(config, :load_restrictions, :none))
+  end
+
+  # `LoadRestrictions.check!/2` takes pre-normalized paths, so the spec a caller
+  # supplies is expanded once on the way in. `normalize/1` is idempotent, so the
+  # recursive descent may re-run it without changing the answer.
+  defp normalize_load_restrictions(config) do
+    case Map.get(config, :load_restrictions) do
+      nil -> config
+      spec -> Map.put(config, :load_restrictions, LoadRestrictions.normalize(spec))
+    end
   end
 
   defp is_interop_resource?(resource, config) do

--- a/lib/ash_introspection/rpc/load_restrictions.ex
+++ b/lib/ash_introspection/rpc/load_restrictions.ex
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.LoadRestrictions do
+  @moduledoc """
+  Shapes the loadable surface of an RPC action: which relationships,
+  calculations and aggregates a client may ask for.
+
+  ## This is not authorization
+
+  Load restrictions are an **API surface** tool, not a security boundary. The
+  reason to reach for them is cost: keeping an expensive aggregate or a deep
+  relationship off an endpoint that has no need for it, so a client cannot turn
+  a list request into a report. They say nothing about who may see a value.
+
+  Authorization is Ash's job and Ash still does it. Policies, field policies and
+  tenancy apply to every load that gets through, exactly as they would if no
+  restriction were declared. A field that must be hidden from an actor is hidden
+  by a policy; adding it to `denied_loads` instead leaves it readable through
+  every other action, and through any caller that is not this pipeline. Upstream
+  `ash_typescript` states the same in `24266dc`.
+
+  ## Where restrictions come from
+
+  Upstream reads them from `Ash.Info.Manifest`, which this library has not
+  adopted (issue #23). Here they arrive on the config map that already threads
+  through field selection, under the `:load_restrictions` key:
+
+      FieldSelector.process(resource, action, fields, %{
+        load_restrictions: {:deny, [comments: [:score]]}
+      })
+
+  Omitting the key means `:none` — every load is permitted, which is what
+  every existing caller gets.
+
+  ## What a restriction says
+
+  A restriction is `{:allow, spec}` or `{:deny, spec}`, where `spec` is a
+  keyword-style nesting of internal (snake_case) field names:
+
+  | Spec | Meaning |
+  |---|---|
+  | `{:deny, [:comments]}` | `comments` and everything under it is refused |
+  | `{:deny, [comments: [:score]]}` | only `comments.score` is refused; `comments` itself is fine |
+  | `{:allow, [:comments]}` | only `comments` may be loaded, and nothing deeper |
+  | `{:allow, [comments: [:score]]}` | `comments` may be loaded as the step to `comments.score` |
+
+  The two directions are deliberately not mirror images. `denied_loads`
+  inherits downwards — denying a parent denies its children — because a deny
+  list is a statement about a subtree. `allowed_loads` does not: allowing
+  `comments` does not allow `comments.score`, because an allow list that
+  inherited downwards would open a subtree its author never enumerated. Naming
+  a nested path implicitly allows the parents needed to reach it, and only
+  those.
+
+  Attributes are never checked. They are selected, not loaded, so they never
+  reach the load statement and no restriction can name one.
+
+  ## How enforcement works
+
+  `check!/2` is called by `AshIntrospection.Rpc.FieldProcessing.FieldSelector`
+  at every point where it appends to the Ash load statement — six of them.
+  A load therefore cannot reach the load statement without passing the check,
+  so there is no second traversal that could disagree with field selection
+  about what is being loaded. Nested paths are checked at every level as
+  selection descends, not re-derived from the finished load statement
+  afterwards.
+  """
+
+  @typedoc "A load path as a list of internal field names, e.g. `[:comments, :score]`."
+  @type path :: [atom()]
+
+  @typedoc "Normalized restrictions: the output of `normalize/1` and the input to `check!/2`."
+  @type t :: :none | {:allow, [path()]} | {:deny, [path()]}
+
+  @doc """
+  Expands a restriction spec into a flat list of paths.
+
+  Accepts `{:allow, spec}`, `{:deny, spec}` and anything else, which becomes
+  `:none`. It is idempotent: passing its own output back returns that output,
+  so a caller that pre-normalizes is not punished for it.
+
+  Returns `t:t/0`.
+
+      iex> AshIntrospection.Rpc.LoadRestrictions.normalize({:deny, [comments: [:score]]})
+      {:deny, [[:comments, :score]]}
+  """
+  @spec normalize(term()) :: t()
+  def normalize({:allow, allowed_loads}), do: {:allow, normalize_paths(List.wrap(allowed_loads))}
+  def normalize({:deny, denied_loads}), do: {:deny, normalize_paths(List.wrap(denied_loads))}
+  def normalize(_), do: :none
+
+  @doc """
+  Checks one load path against normalized restrictions.
+
+  Returns `:ok`, or throws `{:load_not_allowed, [path_string]}` /
+  `{:load_denied, [path_string]}` — the tuples
+  `AshIntrospection.Rpc.ErrorBuilder` turns into a client error. It throws
+  rather than returning an error tuple because its callers sit inside the
+  recursive descent of field selection, which already reports every other
+  refusal by throwing to `process/4`.
+
+  The path string in the thrown tuple is the dotted internal path, e.g.
+  `"comments.score"`, so the client is told which field it may not ask for.
+  """
+  @spec check!(path(), t()) :: :ok
+  def check!(_path, :none), do: :ok
+
+  def check!(path, {:allow, allowed_paths}) do
+    if path_allowed?(path, allowed_paths) do
+      :ok
+    else
+      throw({:load_not_allowed, [format_path(path)]})
+    end
+  end
+
+  def check!(path, {:deny, denied_paths}) do
+    if path_denied?(path, denied_paths) do
+      throw({:load_denied, [format_path(path)]})
+    else
+      :ok
+    end
+  end
+
+  defp normalize_paths(restrictions) when is_list(restrictions) do
+    Enum.flat_map(restrictions, fn
+      field when is_atom(field) ->
+        [[field]]
+
+      {field, nested} when is_atom(field) and is_list(nested) ->
+        nested
+        |> normalize_paths()
+        |> Enum.map(fn nested_path -> [field | nested_path] end)
+
+      # An already-normalized path, which keeps `normalize/1` idempotent.
+      path when is_list(path) ->
+        if Enum.all?(path, &is_atom/1), do: [path], else: []
+
+      _ ->
+        []
+    end)
+  end
+
+  defp normalize_paths(_), do: []
+
+  # Allowed if the path is named outright, or if it is a prefix of a named path
+  # and therefore the step needed to reach it. Children of a named path are not
+  # allowed — see the moduledoc on why the two directions differ.
+  defp path_allowed?(path, allowed_paths) do
+    Enum.any?(allowed_paths, fn allowed_path ->
+      path == allowed_path or List.starts_with?(allowed_path, path)
+    end)
+  end
+
+  # Denied if the path is named outright, or sits under a named path.
+  defp path_denied?(path, denied_paths) do
+    Enum.any?(denied_paths, fn denied_path ->
+      path == denied_path or List.starts_with?(path, denied_path)
+    end)
+  end
+
+  defp format_path(path), do: Enum.map_join(path, ".", &to_string/1)
+end

--- a/test/ash_introspection/rpc/load_restrictions_test.exs
+++ b/test/ash_introspection/rpc/load_restrictions_test.exs
@@ -4,13 +4,204 @@
 
 defmodule AshIntrospection.Rpc.LoadRestrictionsTest do
   @moduledoc """
-  The restriction algebra on its own, before anything calls it (issue #19).
+  Load restrictions shape which relationships, calculations and aggregates an
+  action will load for a client (issue #19). Everything here goes through
+  `FieldSelector.process/4`, the function a generator calls, because the
+  guarantee being tested is about the load statement that comes out of field
+  selection, not about the shape of any one private function.
+
+  The fixtures live in `test/support/load_restriction_resources.ex` and carry
+  one field of every category that appends to the load statement, so every one
+  of the six append sites is exercised from here. Four of them can be made to
+  refuse; the two that only fire when a nested selection already produced a
+  load cannot, because that nested load passed the check one level deeper —
+  see the note on those sites in `FieldSelector`.
   """
   use ExUnit.Case, async: true
 
+  alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
   alias AshIntrospection.Rpc.LoadRestrictions
+  alias AshIntrospection.Test.LoadRestrictions.Article
 
   doctest AshIntrospection.Rpc.LoadRestrictions
+
+  defp process(fields, config \\ %{}) do
+    FieldSelector.process(Article, :read, fields, config)
+  end
+
+  defp deny(spec), do: %{load_restrictions: {:deny, spec}}
+  defp allow(spec), do: %{load_restrictions: {:allow, spec}}
+
+  # Every field shape that reaches an append site, so the compatibility test
+  # below covers all six of them at once.
+  @every_load_shape [
+    ["id", "slug"],
+    ["id", %{"author" => ["id", "articleCount"]}],
+    ["id", %{"meta" => ["label", "shout"]}],
+    ["id", %{"comments" => ["id", "body"]}],
+    ["id", %{"comments" => ["id", "score"]}],
+    ["id", %{"computedMeta" => ["label"]}],
+    ["id", %{"prefixedTitle" => %{"args" => %{"prefix" => "re: "}}}],
+    ["id", %{"extra" => [%{"meta" => ["label", "shout"]}]}]
+  ]
+
+  describe "omitting the config key" do
+    test "leaves every load shape exactly as it was" do
+      for fields <- @every_load_shape do
+        assert process(fields) == process(fields, %{load_restrictions: :none})
+      end
+    end
+
+    test "an empty config loads what was asked for" do
+      assert {:ok, {[:id], [comments: [:id, :score]], _}} =
+               process(["id", %{"comments" => ["id", "score"]}])
+
+      assert {:ok, {[:id], [:slug], _}} = process(["id", "slug"])
+
+      assert {:ok, {[:id], [author: [:id, :article_count]], _}} =
+               process(["id", %{"author" => ["id", "articleCount"]}])
+    end
+
+    test "an unrecognized restriction value is treated as no restriction" do
+      assert process(["id", "slug"], %{load_restrictions: :everything}) ==
+               process(["id", "slug"])
+    end
+  end
+
+  describe "denied_loads" do
+    test "refuses a denied relationship and names it" do
+      assert {:error, {:load_denied, ["comments"]}} =
+               process(["id", %{"comments" => ["id", "body"]}], deny([:comments]))
+    end
+
+    test "refuses a denied calculation at the root" do
+      assert {:error, {:load_denied, ["slug"]}} = process(["id", "slug"], deny([:slug]))
+    end
+
+    test "still loads what is not denied" do
+      assert {:ok, {[:id], [:slug], _}} = process(["id", "slug"], deny([:comments]))
+    end
+
+    test "denies everything under a denied field" do
+      assert {:error, {:load_denied, ["comments.score"]}} =
+               process(["id", %{"comments" => ["id", "score"]}], deny([:comments]))
+    end
+
+    test "a nested deny leaves the parent loadable" do
+      config = deny(comments: [:score])
+
+      assert {:ok, {[:id], [comments: [:id, :body]], _}} =
+               process(["id", %{"comments" => ["id", "body"]}], config)
+
+      assert {:error, {:load_denied, ["comments.score"]}} =
+               process(["id", %{"comments" => ["id", "score"]}], config)
+    end
+
+    test "attributes are never restricted" do
+      assert {:ok, {[:id, :title], [], _}} = process(["id", "title"], deny([:title]))
+    end
+  end
+
+  describe "allowed_loads" do
+    test "loads an allowed relationship" do
+      assert {:ok, {[:id], [comments: [:id, :body]], _}} =
+               process(["id", %{"comments" => ["id", "body"]}], allow([:comments]))
+    end
+
+    test "refuses a load that is not on the list" do
+      assert {:error, {:load_not_allowed, ["slug"]}} =
+               process(["id", "slug"], allow([:comments]))
+    end
+
+    test "allowing a parent does not allow its children" do
+      assert {:error, {:load_not_allowed, ["comments.score"]}} =
+               process(["id", %{"comments" => ["id", "score"]}], allow([:comments]))
+    end
+
+    test "naming a nested path allows the parent needed to reach it" do
+      config = allow(comments: [:score])
+
+      assert {:ok, {[:id], [comments: [:id, :score]], _}} =
+               process(["id", %{"comments" => ["id", "score"]}], config)
+
+      assert {:ok, {[:id], [comments: [:id, :body]], _}} =
+               process(["id", %{"comments" => ["id", "body"]}], config)
+    end
+
+    test "a sibling of an allowed nested path is still refused" do
+      assert {:error, {:load_not_allowed, ["author"]}} =
+               process(["id", %{"author" => ["id", "name"]}], allow(comments: [:score]))
+    end
+  end
+
+  describe "every category that appends to the load statement" do
+    test "a root calculation" do
+      assert {:error, {:load_denied, ["slug"]}} = process(["id", "slug"], deny([:slug]))
+    end
+
+    test "an aggregate reached through a relationship" do
+      assert {:error, {:load_denied, ["author.article_count"]}} =
+               process(
+                 ["id", %{"author" => ["id", "articleCount"]}],
+                 deny(author: [:article_count])
+               )
+    end
+
+    # The embedded attribute only appends when its own selection produced a
+    # load, and that load was already checked one level deeper, so the deeper
+    # path is the one reported. See the note on the append site itself.
+    test "a calculation inside an embedded attribute" do
+      assert {:error, {:load_denied, ["meta.shout"]}} =
+               process(["id", %{"meta" => ["label", "shout"]}], deny([:meta]))
+
+      assert {:error, {:load_denied, ["meta.shout"]}} =
+               process(["id", %{"meta" => ["label", "shout"]}], deny(meta: [:shout]))
+    end
+
+    test "a relationship" do
+      assert {:error, {:load_denied, ["comments"]}} =
+               process(["id", %{"comments" => ["id", "body"]}], deny([:comments]))
+    end
+
+    test "a calculation returning an embedded resource" do
+      assert {:error, {:load_denied, ["computed_meta"]}} =
+               process(["id", %{"computedMeta" => ["label"]}], deny([:computed_meta]))
+    end
+
+    test "a calculation with arguments" do
+      assert {:error, {:load_denied, ["prefixed_title"]}} =
+               process(
+                 ["id", %{"prefixedTitle" => %{"args" => %{"prefix" => "re: "}}}],
+                 deny([:prefixed_title])
+               )
+    end
+
+    test "a calculation inside a union member" do
+      assert {:error, {:load_denied, ["extra.meta.shout"]}} =
+               process(
+                 ["id", %{"extra" => [%{"meta" => ["label", "shout"]}]}],
+                 deny(extra: [:meta])
+               )
+
+      assert {:ok, {[:id, :extra], [extra: [meta: [:shout]]], _}} =
+               process(["id", %{"extra" => [%{"meta" => ["label", "shout"]}]}], deny([:comments]))
+    end
+  end
+
+  describe "nesting depth" do
+    test "a path is checked at each level, not only the first" do
+      # comments is allowed outright, so only the second level can refuse this.
+      assert {:error, {:load_not_allowed, ["comments.score"]}} =
+               process(["id", %{"comments" => ["id", "score"]}], allow([:comments]))
+    end
+
+    test "the reported path is the full path, not the leaf" do
+      assert {:error, {:load_denied, [path]}} =
+               process(["id", %{"author" => ["id", "articleCount"]}], deny([:author]))
+
+      assert path == "author.article_count"
+    end
+  end
 
   describe "normalize/1" do
     test "expands a flat spec" do

--- a/test/ash_introspection/rpc/load_restrictions_test.exs
+++ b/test/ash_introspection/rpc/load_restrictions_test.exs
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.LoadRestrictionsTest do
+  @moduledoc """
+  The restriction algebra on its own, before anything calls it (issue #19).
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.LoadRestrictions
+
+  doctest AshIntrospection.Rpc.LoadRestrictions
+
+  describe "normalize/1" do
+    test "expands a flat spec" do
+      assert LoadRestrictions.normalize({:deny, [:comments]}) == {:deny, [[:comments]]}
+    end
+
+    test "expands a nested spec to full paths and not to the parent" do
+      assert LoadRestrictions.normalize({:allow, [comments: [:score], author: [:article_count]]}) ==
+               {:allow, [[:comments, :score], [:author, :article_count]]}
+    end
+
+    test "anything else is :none" do
+      assert LoadRestrictions.normalize(:none) == :none
+      assert LoadRestrictions.normalize(nil) == :none
+      assert LoadRestrictions.normalize({:allow_maybe, [:comments]}) == :none
+    end
+
+    test "is idempotent" do
+      spec = {:deny, [:comments, [author: [:article_count]]]}
+      once = LoadRestrictions.normalize(spec)
+
+      assert LoadRestrictions.normalize(once) == once
+    end
+  end
+
+  describe "check!/2" do
+    test ":none permits any path" do
+      assert LoadRestrictions.check!([:anything, :at, :all], :none) == :ok
+    end
+
+    test "a denied path throws, naming the dotted path" do
+      restrictions = LoadRestrictions.normalize({:deny, [comments: [:score]]})
+
+      assert catch_throw(LoadRestrictions.check!([:comments, :score], restrictions)) ==
+               {:load_denied, ["comments.score"]}
+
+      assert LoadRestrictions.check!([:comments], restrictions) == :ok
+    end
+
+    test "a deny inherits downwards" do
+      restrictions = LoadRestrictions.normalize({:deny, [:comments]})
+
+      assert catch_throw(LoadRestrictions.check!([:comments, :score], restrictions)) ==
+               {:load_denied, ["comments.score"]}
+    end
+
+    test "an allow does not inherit downwards, but does reach upwards" do
+      restrictions = LoadRestrictions.normalize({:allow, [comments: [:score]]})
+
+      assert LoadRestrictions.check!([:comments], restrictions) == :ok
+      assert LoadRestrictions.check!([:comments, :score], restrictions) == :ok
+
+      assert catch_throw(LoadRestrictions.check!([:comments, :body], restrictions)) ==
+               {:load_not_allowed, ["comments.body"]}
+
+      assert catch_throw(LoadRestrictions.check!([:author], restrictions)) ==
+               {:load_not_allowed, ["author"]}
+    end
+  end
+end

--- a/test/ash_introspection/rpc/load_restrictions_test.exs
+++ b/test/ash_introspection/rpc/load_restrictions_test.exs
@@ -19,6 +19,7 @@ defmodule AshIntrospection.Rpc.LoadRestrictionsTest do
   """
   use ExUnit.Case, async: true
 
+  alias AshIntrospection.Rpc.ErrorBuilder
   alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
   alias AshIntrospection.Rpc.LoadRestrictions
   alias AshIntrospection.Test.LoadRestrictions.Article
@@ -259,6 +260,23 @@ defmodule AshIntrospection.Rpc.LoadRestrictionsTest do
 
       assert catch_throw(LoadRestrictions.check!([:author], restrictions)) ==
                {:load_not_allowed, ["author"]}
+    end
+  end
+
+  describe "the error payload" do
+    test "names the refused path so a client can fix the request" do
+      {:error, error} =
+        process(["id", %{"comments" => ["id", "score"]}], deny(comments: [:score]))
+
+      assert %{type: "load_denied", fields: ["comments.score"], vars: %{fields: "comments.score"}} =
+               ErrorBuilder.build_error_response(error)
+    end
+
+    test "distinguishes a load that is not allowed from one that is denied" do
+      {:error, error} = process(["id", "slug"], allow([:comments]))
+
+      assert %{type: "load_not_allowed", fields: ["slug"]} =
+               ErrorBuilder.build_error_response(error)
     end
   end
 end

--- a/test/support/load_restriction_resources.ex
+++ b/test/support/load_restriction_resources.ex
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.LoadRestrictions.Meta do
+  @moduledoc """
+  An embedded resource with a calculation of its own, so a field selection on
+  it produces a non-empty nested load. That is the shape the embedded branch of
+  `FieldSelector` appends to the load statement, and the one a restriction on
+  the parent attribute has to cover.
+  """
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute :label, :string, public?: true
+  end
+
+  calculations do
+    calculate :shout, :string, expr(label), public?: true
+  end
+end
+
+defmodule AshIntrospection.Test.LoadRestrictions.ComputedMeta do
+  @moduledoc false
+  use Ash.Resource.Calculation
+
+  @impl true
+  def calculate(records, _opts, _context) do
+    Enum.map(records, fn _ -> %AshIntrospection.Test.LoadRestrictions.Meta{label: "computed"} end)
+  end
+end
+
+defmodule AshIntrospection.Test.LoadRestrictions.PrefixedTitle do
+  @moduledoc false
+  use Ash.Resource.Calculation
+
+  @impl true
+  def calculate(records, _opts, %{arguments: %{prefix: prefix}}) do
+    Enum.map(records, fn record -> prefix <> to_string(record.title) end)
+  end
+end
+
+defmodule AshIntrospection.Test.LoadRestrictions.Domain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource AshIntrospection.Test.LoadRestrictions.Author
+    resource AshIntrospection.Test.LoadRestrictions.Article
+    resource AshIntrospection.Test.LoadRestrictions.Comment
+  end
+end
+
+defmodule AshIntrospection.Test.LoadRestrictions.Author do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshIntrospection.Test.LoadRestrictions.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+  end
+
+  relationships do
+    has_many :articles, AshIntrospection.Test.LoadRestrictions.Article, public?: true
+  end
+
+  aggregates do
+    count :article_count, :articles, public?: true
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end
+
+defmodule AshIntrospection.Test.LoadRestrictions.Comment do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshIntrospection.Test.LoadRestrictions.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key :id
+    attribute :body, :string, public?: true
+    attribute :weight, :integer, public?: true
+    attribute :article_id, :uuid, public?: true
+  end
+
+  relationships do
+    belongs_to :article, AshIntrospection.Test.LoadRestrictions.Article, public?: true
+  end
+
+  calculations do
+    calculate :score, :integer, expr(weight * 2), public?: true
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end
+
+defmodule AshIntrospection.Test.LoadRestrictions.Article do
+  @moduledoc """
+  The resource the load-restriction tests select fields from. It carries one
+  field of every category that appends to the Ash load statement — a
+  relationship, a plain calculation, a calculation returning an embedded
+  resource, a calculation with arguments, an aggregate reachable through a
+  relationship, an embedded attribute and a union attribute — so a test can
+  reach each append site through `FieldSelector.process/4`.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.LoadRestrictions.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, public?: true
+    attribute :author_id, :uuid, public?: true
+    attribute :meta, AshIntrospection.Test.LoadRestrictions.Meta, public?: true
+
+    attribute :extra, :union,
+      public?: true,
+      constraints: [
+        types: [
+          meta: [type: AshIntrospection.Test.LoadRestrictions.Meta]
+        ]
+      ]
+  end
+
+  relationships do
+    belongs_to :author, AshIntrospection.Test.LoadRestrictions.Author, public?: true
+    has_many :comments, AshIntrospection.Test.LoadRestrictions.Comment, public?: true
+  end
+
+  calculations do
+    calculate :slug, :string, expr(title), public?: true
+
+    calculate :computed_meta,
+              AshIntrospection.Test.LoadRestrictions.Meta,
+              AshIntrospection.Test.LoadRestrictions.ComputedMeta,
+              public?: true
+
+    calculate :prefixed_title,
+              :string,
+              AshIntrospection.Test.LoadRestrictions.PrefixedTitle do
+      public? true
+      argument :prefix, :string, allow_nil?: false
+    end
+  end
+
+  actions do
+    defaults [:read, :destroy, create: :*, update: :*]
+  end
+end


### PR DESCRIPTION
Closes #19.

The core could not restrict what a client loads, so no generator built on it
could shape an action's loadable surface — `ash_kotlin_multiplatform` ships
without the feature. This ports upstream `ash_typescript` `3aaae6b` and keeps
its framing from `24266dc`.

## What this is not

Load restrictions shape an **API surface**. They keep an expensive relationship
or aggregate off an endpoint that has no need for it. They are **not
authorization**: Ash policies, field policies and tenancy apply to every load
that gets through, and a field denied on one action stays readable through
every other action and through any caller that is not this pipeline. The
moduledoc, the README, the error-builder comment and risk T5 all say so,
because the failure mode of believing otherwise is a security hole.

## How restrictions arrive

Upstream reads them from `Ash.Info.Manifest`. This repo has not adopted the
manifest (#23), so they ride on the config map that field selection already
threads, under an optional `:load_restrictions` key — the same shape
`:is_interop_resource?` and `get_rpc_action_entrypoints` use:

```elixir
FieldSelector.process(Article, :read, fields, %{
  load_restrictions: {:deny, [comments: [:score]]}
})
```

**Omitting the key changes nothing.** No existing consumer has to act. This is
the compatibility guarantee, and `test "leaves every load shape exactly as it
was"` covers it across all eight field shapes that reach an append site.

A deny inherits downwards; an allow does not, but naming a nested path allows
the parents needed to reach it. Attributes are selected rather than loaded and
are never restricted.

## Where the check happens

At each of the **six** points where `FieldSelector` appends to the Ash load
statement — found by reading this file, not by assuming upstream's nine:

| # | Site | Refusable |
|---|---|---|
| 1 | simple calculation or aggregate | yes |
| 2 | embedded / tuple / union attribute with a nested load | no |
| 3 | relationship | yes |
| 4 | calculation and calculation_complex | yes |
| 5 | calculation with arguments | yes |
| 6 | nested union member with a nested load | no |

Sites 2 and 6 fire only when a nested selection already produced a load, and a
passing child implies a passing parent under both `:allow` and `:deny`, so no
request can make them refuse. Both carry a comment saying that and why they
stay. Per `CLAUDE.md`, no test claims otherwise.

Checking at the append site rather than walking the finished load statement is
the point of the upstream commit: a separate traversal has to re-derive which
parts of a load list are loads and which are selects, and upstream's got it
wrong — nested scalar loads escaped it entirely. A check at the append site
cannot disagree with field selection about what is being loaded, because it is
field selection.

Note for #24: a relationship loaded through an `%Ash.Query{}` envelope is a
seventh append site and will need its own `check_load_allowed!/3`. The roadmap
says so.

## Test plan

`mix test` — **342 tests, 0 failures**, up from 309 on `main`. Run five
times, all green.

New: `test/ash_introspection/rpc/load_restrictions_test.exs` (33 tests plus a
doctest), driven through `FieldSelector.process/4` and `ErrorBuilder`, never a
private function. It covers a denied path refused with the dotted path named,
an allowed path still loading, a nested path checked at every level rather than
only the first, and the compatibility guarantee above.

New fixtures in `test/support/load_restriction_resources.ex` — a new file, so
nothing under `test/support/` that #55 is restructuring changes.

The four guards that can refuse are load-bearing: removing the one on site 1
turns 13 tests red.

All five CI gates run locally:

```
mix format --check-formatted      OK
mix compile --warnings-as-errors  OK
mix test                          342 tests, 0 failures
mix hex.audit                     No retired packages found
mix deps.audit                    No vulnerabilities found
```

## Docs

Per `CLAUDE.md`, in this PR: `docs/roadmap.md` moves #19 out of "Next" and
un-blocks it from #23; `docs/decisions.md` records the config-map-instead-of-
manifest choice and its cost; `docs/architecture.md` gains the module and the
edge; `docs/risks.md` gains T5; `README.md` and `CHANGELOG.md` document the
config key.

`docs/roadmap.md` was edited alongside the #55 agent's entry, not over it.

## Architecture

```mermaid
flowchart LR
    subgraph fs["Rpc.FieldProcessing.FieldSelector"]
        s1["simple calc / aggregate"]
        s2["embedded attribute ((no refusal possible))"]
        s3["relationship"]
        s4["calculation / calculation_complex"]
        s5["calculation with args"]
        s6["union member ((no refusal possible))"]
    end

    cfg["config map<br/>:load_restrictions ((NEW))"]
    lr["Rpc.LoadRestrictions ((NEW))<br/>normalize/1, check!/2"]
    eb["Rpc.ErrorBuilder<br/>load_not_allowed, load_denied ((NEW))"]
    load["Ash load statement"]

    cfg -->|"{:deny, [comments: [:score]]}"| lr
    s1 -->|"[:slug]"| lr
    s2 -->|"[:meta]"| lr
    s3 -->|"[:comments]"| lr
    s4 -->|"[:computed_meta]"| lr
    s5 -->|"[:prefixed_title]"| lr
    s6 -->|"[:extra, :meta]"| lr
    lr -->|":ok"| load
    lr -->|"throw"| eb
```
