### PR TITLE
docs: close #26 — no compile-time field-name cache, with the measurement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,51 @@ sites. See `test/ash_introspection/rpc/load_restrictions_test.exs`.
 **They are not authorization.** Ash policies apply to every load that gets
 through. Say so in anything you write about them; risk T5 in
 [`docs/risks.md`](docs/risks.md) explains why it matters.
+### An upstream fix that hangs off a Spark extension cannot be ported here
+
+**Symptom.** You start porting an `ash_typescript` commit, reach for
+`AshIntrospection.Resource`, and there is no such module. Nothing errors — you
+are about to invent an extension to hold the port.
+
+**Why.** This library ships no DSL of its own. `grep 'use Spark.Dsl.Extension'
+lib` returns nothing, and the only extension in the tree is the test-only
+`AshIntrospection.Test.RpcDsl` (see its moduledoc). Upstream hangs transformers
+and verifiers off `AshTypescript.Resource`; the equivalent configuration here
+lives in the **consumer** and arrives as callbacks in the pipeline config
+map — `:format_field_for_client`, `:get_original_field_name`,
+`:field_names_callback`.
+The core reads a consumer's DSL only through
+`Spark.Dsl.Extension.fetch_opt/3` on a section it does not name, in
+`Rpc.Errors`.
+
+**What we do.** When an upstream commit's mechanism is a transformer or a
+verifier, stop and check what it reads before porting. If it reads a DSL
+section, the port is not a port: either the consumer wires it up in its own
+extension, or it waits for #23. Do not add a resource extension to this library
+to hold one — that is #23's decision, not a ticket's. #26 was closed this way;
+[`docs/decisions.md`](docs/decisions.md) has the reasoning and the numbers.
+
+### Field-name formatting is 1.7% of the pipeline, and the cost is the regexes
+
+**Symptom.** An upstream performance commit quotes a large call count, and you
+are about to cache something here on the strength of it.
+
+**Why.** Upstream's figures are upstream's. Measured here at `007eedd` on OTP 27
+and Elixir 1.18.4, over 100 single-record RPC runs through
+`execute_ash_action/1`, `process_result/3` and `format_output_with_request/3`:
+`FieldFormatter.format_field_name/2` is called **6 times per record** — the
+selected field names plus the `"success"` and `"data"` envelope literals — at
+~470 ns each. That is 0.73 ms against 41 ms of `execute_ash_action/1`. Ash
+action execution is 95% of the pipeline.
+
+Within that 470 ns, `Macro.camelize/1` — the work that transforms the name —
+is ~60 ns. The rest is `is_camel_case?/1`, `is_pascal_case?/1` and
+`is_snake_case?/1`, which each run one or two `String.match?/2` calls at ~295 ns
+apiece. A binary-walk clause computing the same answer measures ~10 ns.
+
+**What we do.** Measure before optimising this function, and optimise the
+predicates rather than caching the result. A cache helps resource fields only;
+the predicates are on every caller's path, codegen and errors included.
 
 ### No stdlib `JSON`: `mix.exs` declares `elixir: "~> 1.15"`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,18 +235,18 @@ extension, or it waits for #23. Do not add a resource extension to this library
 to hold one — that is #23's decision, not a ticket's. #26 was closed this way;
 [`docs/decisions.md`](docs/decisions.md) has the reasoning and the numbers.
 
-### Field-name formatting is 1.7% of the pipeline, and the cost is the regexes
+### Field-name formatting is ~2% of the pipeline; the cost is the regexes
 
 **Symptom.** An upstream performance commit quotes a large call count, and you
 are about to cache something here on the strength of it.
 
-**Why.** Upstream's figures are upstream's. Measured here at `007eedd` on OTP 27
-and Elixir 1.18.4, over 100 single-record RPC runs through
+**Why.** Upstream's figures are upstream's. Measured here at `0dd9ac5` on OTP
+27 and Elixir 1.18.4, over 100 single-record RPC runs through
 `execute_ash_action/1`, `process_result/3` and `format_output_with_request/3`:
 `FieldFormatter.format_field_name/2` is called **6 times per record** — the
 selected field names plus the `"success"` and `"data"` envelope literals — at
-~470 ns each. That is 0.73 ms against 41 ms of `execute_ash_action/1`. Ash
-action execution is 95% of the pipeline.
+~470 ns each. That is under 1 ms against 32-42 ms of `execute_ash_action/1`.
+Ash action execution is 95% of the pipeline.
 
 Within that 470 ns, `Macro.camelize/1` — the work that transforms the name —
 is ~60 ns. The rest is `is_camel_case?/1`, `is_pascal_case?/1` and

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -69,23 +69,26 @@ cannot see inside a closure the consumer supplies.
 
 **Why — the cost the ticket describes is not the cost this library has.** The
 ticket quotes upstream's ~1,500 calls of one `(field, resource, formatter)`
-triple per sync. Measured here on `main` at `007eedd`, OTP 27 and Elixir
-1.18.4, over 100 single-record RPC runs against `AshIntrospection.Test.Account`
-with four public fields selected, each run passing through
-`execute_ash_action/1`, `process_result/3` and `format_output_with_request/3`:
+triple per sync. Measured here at `0dd9ac5`, OTP 27 and Elixir 1.18.4, over 100
+single-record RPC runs against `AshIntrospection.Test.Account` with four public
+fields selected, each run passing through `execute_ash_action/1`,
+`process_result/3` and `format_output_with_request/3`. Call counts come from
+`:erlang.trace/3` on `{FieldFormatter, :format_field_name, 2}`, timings from
+`:timer.tc/1` on warmed loops; the ranges are five runs on one laptop, so read
+the shares, not the milliseconds:
 
 | Measurement | Value |
 |---|---|
 | `format_field_name/2` calls | 6 per record — 4 field names, plus `"success"` and `"data"` |
 | `format_field_name/2` cost | ~470 ns per call, warm |
-| Time in `format_field_name/2` | 0.73 ms per 100-record run |
-| `execute_ash_action/1` | 41.0 ms (410 µs per record) |
-| `process_result/3` | 0.55 ms |
-| `format_output_with_request/3` | 1.39 ms |
-| Share of the output-formatting stage | 53% |
-| **Share of the whole pipeline** | **1.7%** |
+| Time in `format_field_name/2` | 0.65–0.82 ms per 100-record run |
+| `execute_ash_action/1` | 32–42 ms (320–420 µs per record) |
+| `process_result/3` | 0.44–0.55 ms |
+| `format_output_with_request/3` | 1.15–1.48 ms |
+| Share of the output-formatting stage | 53–59% |
+| **Share of the whole pipeline** | **1.7–2.1%** |
 
-A perfect cache replaces ~470 ns with a ~7 ns map lookup, so 1.7% of pipeline
+A perfect cache replaces ~470 ns with a ~7 ns map lookup, so ~2% of pipeline
 wall clock is the ceiling on the entire idea. Ash action execution is 95% of it.
 
 **Why — a transformer would reach only two thirds of even that.** Tracing the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -45,6 +45,73 @@ manifest-backed DSL would catch that at compile time. And this is an API
 surface tool, not authorization — Ash policies still apply to every load that
 gets through, which the moduledoc says plainly because the failure mode of
 believing otherwise is a security hole.
+## 2026-09-09 — No compile-time field-name cache: nothing to attach it to
+
+**Decided.** Do not port upstream `ash_typescript`'s `PersistFormattedFields`
+Spark transformer (`b2d30bf`), and do not build a variant of it here. Issue #26
+is closed as decided against. The measurement below is the evidence; re-run it
+before reopening.
+
+**Why — the transformer cannot exist in this library.** A Spark transformer is
+listed in a `use Spark.Dsl.Extension` call, and **this library ships no DSL of
+its own**: `grep 'use Spark.Dsl.Extension' lib` returns nothing, and the only
+extension in the tree is the test-only `AshIntrospection.Test.RpcDsl`.
+Upstream's transformer body reads `[:typescript], :field_names` off the
+resource's DSL state, a section this library neither owns nor can name. The
+equivalent mapping lives entirely in the consumer:
+`ash_kotlin_multiplatform` holds it in
+`AshKotlinMultiplatform.Resource.Info.kotlin_field_names/1` and injects the
+lookup as the `:format_field_for_client` closure in the pipeline config. There
+is no public `format_field_for_client/3` here at all — only the private
+`ValueFormatter.format_field_for_client/4`, which calls the consumer's closure
+or falls back to `FieldFormatter.format_field_name/2`. A cache the core owns
+cannot see inside a closure the consumer supplies.
+
+**Why — the cost the ticket describes is not the cost this library has.** The
+ticket quotes upstream's ~1,500 calls of one `(field, resource, formatter)`
+triple per sync. Measured here on `main` at `007eedd`, OTP 27 and Elixir
+1.18.4, over 100 single-record RPC runs against `AshIntrospection.Test.Account`
+with four public fields selected, each run passing through
+`execute_ash_action/1`, `process_result/3` and `format_output_with_request/3`:
+
+| Measurement | Value |
+|---|---|
+| `format_field_name/2` calls | 6 per record — 4 field names, plus `"success"` and `"data"` |
+| `format_field_name/2` cost | ~470 ns per call, warm |
+| Time in `format_field_name/2` | 0.73 ms per 100-record run |
+| `execute_ash_action/1` | 41.0 ms (410 µs per record) |
+| `process_result/3` | 0.55 ms |
+| `format_output_with_request/3` | 1.39 ms |
+| Share of the output-formatting stage | 53% |
+| **Share of the whole pipeline** | **1.7%** |
+
+A perfect cache replaces ~470 ns with a ~7 ns map lookup, so 1.7% of pipeline
+wall clock is the ceiling on the entire idea. Ash action execution is 95% of it.
+
+**Why — a transformer would reach only two thirds of even that.** Tracing the
+arguments of all six calls for one record: four are resource field atoms, which
+a transformer could persist. `"success"` and `"data"` are string literals in
+the response envelope, formatted on every response and belonging to no
+resource. No resource-attached cache reaches them.
+
+**What we found instead.** The cost is not the missing cache, it is the
+predicate. `format_field_name/2` runs `is_camel_case?/1`, `is_pascal_case?/1`
+or `is_snake_case?/1`, each one or two `String.match?/2` calls against a regex.
+One `String.match?/2` measures ~295 ns; a binary-walk clause computing the same
+answer measures ~10 ns; and `Macro.camelize/1`, the work that actually
+transforms the name, is only ~60 ns. Replacing the three predicates would cut
+the function to roughly 130 ns for every caller, resource field or not, with no
+extension, no transformer and no consumer wiring. That is filed as its own
+issue rather than folded into this one: those predicates decide casing
+behaviour across the whole library, and a faithful rewrite needs equivalence
+tests of its own.
+
+**Cost.** Upstream drift widens by one more commit, and this drift is invisible
+in a diff — a reader comparing the two trees sees a transformer that is
+missing, not one that was declined. This entry is the marker. If #23 lands and
+the library adopts `Ash.Info.Manifest`, upstream's successor to this work is
+`Manifest.Custom.formatted_field_names`, which arrives with the manifest for
+free. That is the second reason not to build a bespoke mechanism now.
 
 ## 2026-09-09 — The metadata allowlist stays with the caller
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,8 +169,8 @@ dozen other items.
   transformer is listed in a `use Spark.Dsl.Extension` call and this library
   ships no DSL, so upstream's `PersistFormattedFields` has nothing to attach
   to; the resource-to-client mapping lives in the consumer's closure, which a
-  cache in the core cannot see into. Measured on `main` at `007eedd`,
-  `format_field_name/2` is 1.7% of RPC pipeline wall clock — 6 calls per
+  cache in the core cannot see into. Measured at `0dd9ac5`,
+  `format_field_name/2` is ~2% of RPC pipeline wall clock — 6 calls per
   record, two of them response-envelope literals no resource cache would ever
   reach. The cost is the regex predicates, not the missing cache: see
   [decisions.md](decisions.md) for the numbers and the cheaper fix.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -128,7 +128,9 @@ dozen other items.
 1. **#23 — adopt `Ash.Info.Manifest`.** Upstream replaced live introspection
    with a precomputed Spark manifest in `ash` 3.32.3. This repo still calls
    `Ash.Resource.Info` at ~66 sites, which is why upstream's type-discovery
-   fixes do not port cleanly. Blocks #24, #25, #26 and more, and
+   fixes do not port cleanly. Blocks #24 and #25 and more, and it is where
+   the field-name cache declined in #26 would arrive for free, as upstream's
+   `Manifest.Custom.formatted_field_names`. It also
    carries the remainder of #21: entrypoint scoping here branches on the action
    kind, where upstream's `Reachability` walks the accepted attributes, loads
    and relationship depth of each declared action.
@@ -140,8 +142,7 @@ dozen other items.
 3. **#18 — the RPC test floor.** Coverage arrives with each fix by preference,
    but the harness and the fixtures are still a ticket of their own.
 4. **Upstream parity features**: #24 (relationship query envelopes), #25
-   (calculation load-through and nested first-aggregates), #26 (persist
-   formatted field names via a Spark transformer). #24 touches the same
+   (calculation load-through and nested first-aggregates). #24 touches the same
    `FieldSelector` clauses #19 just guarded: a relationship loaded through an
    `%Ash.Query{}` envelope is a seventh append site and needs its own
    `check_load_allowed!/3`.
@@ -164,6 +165,15 @@ dozen other items.
 - **Shipping this library's own `config/`.** `mix.exs` keeps `config` out of
   the published `files` list so a consumer chooses its own Ash settings; see
   the `default_string_length_count` entry in [decisions.md](decisions.md).
+- **Persisting formatted field names via a Spark transformer** (#26). A
+  transformer is listed in a `use Spark.Dsl.Extension` call and this library
+  ships no DSL, so upstream's `PersistFormattedFields` has nothing to attach
+  to; the resource-to-client mapping lives in the consumer's closure, which a
+  cache in the core cannot see into. Measured on `main` at `007eedd`,
+  `format_field_name/2` is 1.7% of RPC pipeline wall clock — 6 calls per
+  record, two of them response-envelope literals no resource cache would ever
+  reach. The cost is the regex predicates, not the missing cache: see
+  [decisions.md](decisions.md) for the numbers and the cheaper fix.
 
 ## Keeping this page current
 


### PR DESCRIPTION
Closes #26, as **decided against, with evidence**.

The ticket asked to port upstream `ash_typescript`'s `PersistFormattedFields`
Spark transformer (`b2d30bf`). I measured first, then found the port cannot be
built here, and that the cost it targets is 1.7% of pipeline wall clock in this
library. This PR is the measurement and the decision; it changes no code in
`lib/`.

## Why the transformer cannot exist here

A Spark transformer is listed in a `use Spark.Dsl.Extension` call, and **this
library ships no DSL of its own** — `grep 'use Spark.Dsl.Extension' lib`
returns nothing, and the only extension in the tree is the test-only
`AshIntrospection.Test.RpcDsl`, whose moduledoc already says so.

Upstream's transformer body reads `[:typescript], :field_names` off the
resource's DSL state. This library neither owns nor can name that section. The
equivalent mapping lives entirely in the consumer:
`ash_kotlin_multiplatform` holds it in
`AshKotlinMultiplatform.Resource.Info.kotlin_field_names/1` and injects the
lookup as the `:format_field_for_client` closure in the pipeline config.

There is also no public `format_field_for_client/3` here — only the private
`ValueFormatter.format_field_for_client/4`, which calls the consumer's closure
or falls back to `FieldFormatter.format_field_name/2`. A cache the core owns
cannot see inside a closure the consumer supplies.

## The measurement

Branch base `0dd9ac5` (main with #19 merged), OTP 27 / Elixir 1.18.4, 100
single-record RPC runs against `AshIntrospection.Test.Account` with four public
fields selected, each passing through `execute_ash_action/1`,
`process_result/3` and `format_output_with_request/3`. Call counts by
`:erlang.trace/3` on `{FieldFormatter, :format_field_name, 2}`; timings by
`:timer.tc/1` on warmed loops. Ranges are five runs on one laptop — read the
shares, not the milliseconds.

| Measurement | Value |
|---|---|
| `format_field_name/2` calls | **6 per record** (upstream quotes ~1,500 per sync) |
| `format_field_name/2` cost | ~470 ns per call, warm |
| Time in `format_field_name/2` | 0.65–0.82 ms per 100-record run |
| `execute_ash_action/1` | 32–42 ms (320–420 µs per record) |
| `process_result/3` | 0.44–0.55 ms |
| `format_output_with_request/3` | 1.15–1.48 ms |
| Share of the output-formatting stage | 53–59% |
| **Share of the whole pipeline** | **1.7–2.1%** |

A perfect cache replaces ~470 ns with a ~7 ns map lookup, so ~2% is the
ceiling on the whole idea. Ash action execution is 95% of the pipeline.

**A transformer would reach only four of those six calls.** Tracing the
arguments for one record:

```
:active / :camel_case   -- resource field (a transformer could cache)
:id     / :camel_case   -- resource field
:name   / :camel_case   -- resource field
:email  / :camel_case   -- resource field
"success" / :camel_case -- envelope literal (out of reach)
"data"    / :camel_case -- envelope literal (out of reach)
```

`"success"` and `"data"` are string literals in the response envelope,
formatted on every response and belonging to no resource.

## What the cost actually is

Not the missing cache — the predicate. `format_field_name/2` runs
`is_camel_case?/1`, `is_pascal_case?/1` or `is_snake_case?/1`, each one or two
`String.match?/2` calls against a regex:

| Operation | ns/call |
|---|---|
| `String.match?("user_name", ~r/^[a-z][a-zA-Z0-9]*$/)` | 295 |
| `String.match?("user_name", ~r/[A-Z]/)` | 322 |
| binary-walk clause computing the same answer | 10 |
| `Macro.camelize("user_name")` — the actual work | 60 |
| `format_field_name(:user_name, :camel_case)` — whole call | 467 |

Replacing the three predicates would cut the function to roughly 130 ns for
**every** caller — codegen and error formatting included, not just resource
fields — with no extension, no transformer and no consumer wiring. That is
~3.6x on the function against the transformer's reach of four calls in six.

I did not fold it into this PR: those three predicates decide casing behaviour
across the whole library, and a faithful rewrite needs equivalence tests of its
own. Filed separately.

Rebased onto `main` after #19 (PR #59) merged; the docs conflicts in
`docs/decisions.md`, `docs/roadmap.md` and `CLAUDE.md` were resolved by keeping
both sides' entries, and the timings were re-run on the rebased branch.

## Changes

- `docs/decisions.md` — dated entry: the decision, the reasoning, the table
  above, and what it cost.
- `docs/roadmap.md` — #26 moved from "Next" out of the upstream-parity list
  into "Decided against"; the #23 entry now notes that upstream's successor,
  `Manifest.Custom.formatted_field_names`, arrives with the manifest for free.
- `CLAUDE.md` — two lessons. #19, #24 and #25 will hit the same wall, so the
  first says to check what an upstream transformer *reads* before porting it,
  and not to invent a resource extension to hold one (that is #23's decision).
  The second records the measurement so the next session does not adopt
  upstream's call counts as ours.

## Test plan

All five CI gates run locally on this branch:

```
mix format --check-formatted   OK
mix compile --warnings-as-errors   clean
mix test                       1 doctest, 342 tests, 0 failures
mix hex.audit                  No retired packages found
mix deps.audit                 No vulnerabilities found.
```

342 tests matches `main` after #19 merged. No code in `lib/` changed, so no new tests are
warranted; the claim this PR makes is a measurement, and the method is recorded
in `docs/decisions.md` precisely enough to re-run.

## If you disagree

The path back is #23. If the library adopts `Ash.Info.Manifest`, upstream's
successor to this work is `Manifest.Custom.formatted_field_names` and it comes
with the manifest — which is the second reason not to build a bespoke
mechanism now.


## Follow-up

Filed #61 for the predicate rewrite, with the table above attached.
