### PR TITLE
fix: untyped map actions lost their payload — the skip guard could never match (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,24 @@ and this project adheres to
 
 ### Fixed
 
+- A generic action returning an unconstrained `:map` hands its payload to the
+  client verbatim, values included
+  ([#62](https://github.com/udin-io/ash_introspection/issues/62)). The check
+  that skips field selection for such an action compared the whole constraints
+  keyword list against `[]`. Ash normalises a generic action's constraints
+  through `Ash.Type.init/2`, which fills in the return type's declared
+  defaults, and `Ash.Type.Map` declares `preserve_nil_values?` with
+  `default: false`, so the list always read `[preserve_nil_values?: false]` and
+  the skip never fired. Every such response went through the typed path, which
+  has no field definitions to work from: it looked up each requested name in a
+  map that does not use those names and wrote `nil` for every miss, so
+  `%{"_id" => "audit-1", "field_name" => "title"}` reached the client as
+  `%{id: nil, name: nil, email: nil}`. This never worked; it is not a
+  regression from the `ash` 3.11.3 → 3.33.1 bump in
+  [#46](https://github.com/udin-io/ash_introspection/issues/46), because
+  3.11.3 normalises the same action to the same
+  `[preserve_nil_values?: false]`. The condition now asks whether `:fields` is
+  present and non-empty, so an incidental constraint cannot kill it again.
 - Action metadata is formatted once, by the type its action declared for it
   ([#20](https://github.com/udin-io/ash_introspection/issues/20)). A metadata
   name is not an attribute, so stage 4 looked it up on the resource, found

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,42 @@ camelCase changes under a second pass: `AshIntrospection.Test.RevisionInfo`
 maps `:revision` to `_rev`, which a second camelization rewrites to `rev`. See
 `test/ash_introspection/rpc/pipeline_metadata_formatting_test.exs`.
 
+### Never compare a whole constraints keyword list against `[]` — fixed in #62
+
+**Symptom.** A branch that should fire for a type carrying no interesting
+constraints never fires. Nothing errors and nothing warns; the code takes the
+other path and every test still passes, because the other path returns
+something plausible.
+
+**Why.** Ash normalises constraints against the type's declared schema before
+you ever see them. A generic action goes through
+`Ash.Resource.Actions.Action.transform/1` →
+`Ash.Type.init/2` → `Ash.Type.validate_constraints/2` →
+`Spark.Options.validate/2`, which fills in **every default the type
+declares** (ash 3.33.1, `deps/ash/lib/ash/type/type.ex:2647`). So
+`action :raw_payload, :map` with no `constraints` block arrives as
+`[preserve_nil_values?: false]`, from `Ash.Type.Map`'s schema
+(`deps/ash/lib/ash/type/map.ex:7`). Attributes, arguments and metadata are
+normalised the same way. In #62 the untyped-map fast path in `Rpc.Pipeline`
+asked for `action.constraints == []`, so it was dead from the first commit and
+every untyped-map response went through the typed path, which nils each
+requested field name the caller's map does not happen to use. Measured
+2026-09-10: ash 3.11.3 and 3.33.1 both normalise that action to
+`[preserve_nil_values?: false]`, so an ash bump did not cause it and an ash pin
+will not save the next one.
+
+**What we do.** Ask about the constraint key you actually need.
+`AshIntrospection.TypeSystem.Introspection.has_field_constraints?/1` answers
+"does this shape have `:fields` to select against", and it is the only right
+way to phrase that question here. Everywhere else, read the key with
+`Keyword.get(constraints, :fields, [])` — the `[]` default is what keeps
+`field_specs == []` alive at the four sites that use it. This grep must stay
+empty:
+
+```
+grep -rn 'constraints == \[\]\|constraints == nil\|Enum.empty?(constraints' lib
+```
+
 ### Never call `Ash.DataLayer.Ets.stop/1` in a test — fixed in #55
 
 **Symptom, before the fix.** Roughly one `mix test` run in forty failed on
@@ -354,7 +390,8 @@ mix hex.audit
 mix deps.audit
 ```
 
-`main` is at **309 tests, 0 failures**. A pull request that changes that number
+`main` is at **348 tests + 1 doctest, 0 failures** (measured 2026-09-10 on the
+#62 branch). A pull request that changes that number
 downward, or that leaves a compiler warning, is not finished. Never suppress a
 warning — fix the cause.
 

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -82,13 +82,20 @@ yet and is not on the board.
 **The risk.** `lib/ash_introspection/rpc/` had **zero** test coverage until the
 week of 2026-09-09 (#18). Coverage arrived as regression tests attached to the
 seven fixes shipped in 0.3.0 — one test per fixed bug, not a suite that
-describes the pipeline. `main` is at 309 tests, and whole modules
+describes the pipeline. `main` is at 348 tests, and whole modules
 (`value_formatter.ex`, `field_extractor.ex`, `atomizer.ex`) are still exercised
 only incidentally.
 
 **Why it bites.** Every open correctness issue on the board (#35, #40, #16)
 touches code that has no behavioural test around it, so a fix can break a
 neighbour silently.
+
+**A test that asserts the shape and not the values is worse than none.** #62
+was silent data loss — an untyped-map response reached the client with every
+value replaced by `nil` — and the one existing test on that action passed
+throughout, because it asked for an empty field list and so took a different
+branch. Coverage counted; the payload did not. Assert the values a caller
+receives, not the key casing and not the presence of keys.
 
 **What we watch.** `mix test` count and which modules new tests land in. CI
 runs the suite on every pull request as of #32.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,23 @@ which come first. Numbers in parentheses are GitHub issues on
 
 ### Unreleased
 
+- **Stop nilling the payload of a generic action that returns an unconstrained
+  `:map`** (#62). `unconstrained_map_action?/1` skips field selection when
+  there are no field definitions to select against, and it asked for
+  `action.constraints == []`. Ash normalises a generic action's constraints
+  through `Ash.Type.init/2`, which fills in the return type's declared
+  defaults, and `Ash.Type.Map` declares `preserve_nil_values?` with
+  `default: false`, so the list always read `[preserve_nil_values?: false]` and
+  the skip never fired. Every such response took the typed path, which looked
+  up each requested field name in a map that does not use those names and wrote
+  `nil` per miss: `%{"_id" => "audit-1", "field_name" => "title"}` reached the
+  client as `%{id: nil, name: nil, email: nil}`. Not a regression from the
+  `ash` bump in #46 — 3.11.3 normalises the same action to the same
+  constraints, measured 2026-09-10 against both versions — so the feature
+  never worked. The condition now asks whether `:fields` is present and
+  non-empty, through the `Introspection.has_field_constraints?/1` the same file
+  already used for the same question. Blocked `ash_kotlin_multiplatform#48`.
+  See [`CLAUDE.md`](../CLAUDE.md).
 - **Shape an action's loadable surface with `allowed_loads` / `denied_loads`**
   (#19). The core could not restrict what a client loads, so no generator
   built on it could either, and `ash_kotlin_multiplatform` shipped without the

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -788,9 +788,20 @@ defmodule AshIntrospection.Rpc.Pipeline do
   # Type Introspection Helpers
   # ---------------------------------------------------------------------------
 
+  # "Unconstrained" means no `:fields` to select against — never "no
+  # constraints at all". Ash normalises a generic action's constraints through
+  # `Ash.Type.init/2`, which fills in every default the return type declares, so
+  # an action returning a bare `:map` arrives here carrying
+  # `[preserve_nil_values?: false]` from `Ash.Type.Map`'s constraint schema
+  # (`deps/ash/lib/ash/type/map.ex:7`). #62: this test used to compare the
+  # keyword list against `[]`, which that default can never equal, so the skip
+  # never fired and every untyped-map response went through the typed path and
+  # came back as `nil` per requested field. Ask about `:fields` — the thing the
+  # typed path actually needs — and a future ash release adding another default
+  # cannot kill the check again.
   defp unconstrained_map_action?(action) do
     action.type == :action && action.returns == Ash.Type.Map &&
-      (action.constraints == nil || action.constraints == [])
+      not Introspection.has_field_constraints?(action.constraints || [])
   end
 
   defp action_returns_resource?(action) do

--- a/test/ash_introspection/rpc/pipeline_unconstrained_map_test.exs
+++ b/test/ash_introspection/rpc/pipeline_unconstrained_map_test.exs
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineUnconstrainedMapTest do
+  @moduledoc """
+  Pins that a generic action returning an unconstrained `:map` hands its
+  payload to the client untouched — every value, every key.
+
+  An unconstrained `:map` is an explicit opt-out of typing. The pipeline has no
+  field definitions to select against, so field selection must be skipped
+  entirely and the map returned verbatim. #62 found the guard that skips it was
+  dead: it asked for `action.constraints == []`, but `Ash.Type.Map` declares
+  `preserve_nil_values?` with a default, so `Ash.Type.init/2` normalises every
+  such action to `[preserve_nil_values?: false]` and the guard never matched.
+  Every request fell through to the typed path, which looked up the requested
+  field names in a map that does not use them and wrote `nil` for each miss —
+  silent data loss, not a re-keying nit.
+
+  `AshIntrospection.Test.AuditedRecord.raw_payload` is the fixture: an
+  unconstrained `:map` whose keys are the caller's, including a leading
+  underscore (`_id`) and a snake_case word (`field_name`) that a formatter
+  would rewrite if it were allowed to.
+
+  A casing assertion cannot see this bug, and neither can a template that
+  happens to name the map's own keys. The requests below ask for field names
+  the payload does not carry — which is what a generated client does — and
+  assert the values, not the casing.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.AuditedRecord
+  alias AshIntrospection.Test.MetadataDomain
+
+  # The map the fixture's action hands back, verbatim.
+  @raw_audit %{
+    "_id" => "audit-1",
+    "field_name" => "title",
+    "nested" => %{"_rev" => "rev-7", "changed_by" => "ops-team"}
+  }
+
+  defp response(extraction_template) do
+    request =
+      %{
+        domain: MetadataDomain,
+        resource: AuditedRecord,
+        action: Ash.Resource.Info.action(AuditedRecord, :raw_payload),
+        rpc_action: %{},
+        input: %{},
+        context: %{},
+        select: [],
+        load: [],
+        extraction_template: extraction_template,
+        show_metadata: []
+      }
+      |> Request.new()
+
+    {:ok, ash_result} = Pipeline.execute_ash_action(request)
+    {:ok, processed} = Pipeline.process_result(ash_result, request)
+
+    Pipeline.format_output_with_request(%{success: true, data: processed}, request)
+  end
+
+  describe "the premise" do
+    test "ash normalises an unconstrained map action's constraints to a non-empty list" do
+      action = Ash.Resource.Info.action(AuditedRecord, :raw_payload)
+
+      assert action.returns == Ash.Type.Map
+      assert action.constraints == [preserve_nil_values?: false]
+      refute AshIntrospection.TypeSystem.Introspection.has_field_constraints?(action.constraints)
+    end
+  end
+
+  describe "a generic action returning an unconstrained map" do
+    test "hands the whole payload back when the client asks for names it does not carry" do
+      assert %{"data" => @raw_audit, "success" => true} = response([:id, :name, :email])
+    end
+
+    test "keeps the keys the caller wrote, including a leading underscore" do
+      %{"data" => data} = response([:id, :name, :email])
+
+      assert Map.keys(data) |> Enum.sort() == ["_id", "field_name", "nested"]
+      assert data["_id"] == "audit-1"
+      assert data["field_name"] == "title"
+    end
+
+    test "leaves nested keys alone" do
+      %{"data" => data} = response([:id, :name, :email])
+
+      assert data["nested"] == %{"_rev" => "rev-7", "changed_by" => "ops-team"}
+    end
+
+    test "hands the whole payload back when the client asks for the map's own keys" do
+      %{"data" => data} = response([:_id, :field_name, :nested])
+
+      assert data == @raw_audit
+    end
+
+    test "hands the whole payload back when the client asks for nothing" do
+      %{"data" => data} = response([])
+
+      assert data == @raw_audit
+    end
+  end
+end


### PR DESCRIPTION
Closes #62.

A generic action returning an unconstrained `:map` reached the client with
every value replaced by `nil`. The fast path that should have skipped field
selection for such an action was dead from its first commit, and no test could
see it. This restores the payload and re-phrases the condition so a future ash
release cannot kill it again.

## Why the guard was dead

`unconstrained_map_action?/1` asked for `action.constraints == nil || action.constraints == []`.

Ash never hands you the constraints you wrote. A generic action passes through
`Ash.Resource.Actions.Action.transform/1`
(`deps/ash/lib/ash/resource/actions/action/action.ex:54`) →
`Ash.Type.init/2` → `Ash.Type.validate_constraints/2` →
`Spark.Options.validate/2` (`deps/ash/lib/ash/type/type.ex:2647`), which fills
in every default the return type declares. `Ash.Type.Map` declares
`preserve_nil_values?` with `default: false` (`deps/ash/lib/ash/type/map.ex:7`),
so `action :raw_payload, :map` arrives carrying `[preserve_nil_values?: false]`.
That list is never `[]`, so the skip never fired.

Every untyped-map response therefore took the typed path, which has no field
definitions to work from. It looks up each requested field name in the caller's
map, finds nothing, and writes `nil`:

```
%{"_id" => "audit-1", "field_name" => "title", "nested" => %{...}}
  ->  %{id: nil, name: nil, email: nil}
```

The caller's own keys are gone, not re-cased. Silent data loss.

## Not a regression from the ash bump

#46 moved `ash` 3.11.3 → 3.33.1, so the first question was whether we broke
this. We did not. Measured 2026-09-10 by compiling the same one-action resource
against both versions:

| ash | `action.returns` | `action.constraints` | guard fires? |
| --- | --- | --- | --- |
| 3.11.3 | `Ash.Type.Map` | `[preserve_nil_values?: false]` | no |
| 3.33.1 | `Ash.Type.Map` | `[preserve_nil_values?: false]` | no |

3.11.3 declares `preserve_nil_values?` with the same default and runs the same
`Ash.Type.init/2` chain from the same `transform/1`. The feature never worked.
The CHANGELOG entry says so.

## No other dead guards of this shape

The bump was worth checking for siblings. There are none:

- `grep -rn 'constraints == \[\]\|constraints == nil\|Enum.empty?(constraints' lib`
  now returns nothing.
- Every other place that asks the same question reads the key rather than the
  list — `Keyword.get(constraints, :fields, [])` — so the `[]` comparison
  that follows is against a value that really can be `[]`. That is the live
  pattern at `result_processor.ex:437`, `value_formatter.ex:335`,
  `field_selector.ex:629` and `validation_error_types.ex:213`.
- No `== %{}` on anything ash normalises.

## The fix

Ask about `:fields` — the thing the typed path actually needs — through
`Introspection.has_field_constraints?/1`, which this same file already uses to
make the same decision at `get_action_return_type_info/1`. Incidental
constraints no longer matter, and no new helper was added.

## The test

`test/ash_introspection/rpc/pipeline_unconstrained_map_test.exs`, 6 tests,
written failing first. Confirmed failing on `main` with 4 failures, each
reporting `%{id: nil, name: nil, email: nil}` — the right reason.

Three things it does that the old coverage did not:

- **Asserts the values**, not the key casing.
- **Asserts the keys are not rewritten** — `_id` stays `_id`, `field_name`
  stays `field_name` — which was the guard's original intent.
- **Asks for field names the payload does not carry**, which is what a
  generated client does. The one pre-existing assertion on `:raw_payload`
  passed an empty extraction template, and `template == []` reaches
  `normalize_primitive/1` down a different branch, so it was green throughout
  the bug's life.

It also pins the premise: a test asserting
`action.constraints == [preserve_nil_values?: false]`, so if ash ever stops
normalising this way the reason for the current phrasing fails loudly instead of
rotting.

## Test plan

```
mix format --check-formatted
mix compile --force --warnings-as-errors
mix test
mix hex.audit
mix deps.audit
```

`348 tests + 1 doctest, 0 failures` (was 342 + 1). No new warnings.

## Found while here, and NOT fixed

A generic action returning `{:array, :map}` loses its values the same way.
`action :rows, {:array, :map}` normalises to
`{:array, Ash.Type.Map}` with `[items: [preserve_nil_values?: false]]`, which
`unconstrained_map_action?/1` does not match by design — it names
`Ash.Type.Map` only. Measured on this branch:

```
[%{"_id" => "a-1", "name" => "KSR"}]  ->  [%{id: nil, name: "KSR"}]
```

Same family, different guard, and it is adjacent to #57 (plain lists are not
formatted at all). Left out to keep this PR to one behaviour change; filed
separately.

## Documentation

- `CHANGELOG.md` — under Fixed, worded as a never-worked bug rather than a
  regression, with the evidence.
- `docs/roadmap.md` — #62 into Shipped / Unreleased.
- `docs/risks.md` — risk T3 gains the part #62 proves: a test that asserts
  shape and not values passed through the whole life of a data-loss bug. Test
  count refreshed.
- `CLAUDE.md` — a new lesson, "Never compare a whole constraints keyword list
  against `[]`", with the call chain, the two-version measurement and a grep
  that has to stay empty. Stale test count refreshed.
