### PR TITLE
fix: format multi-record reads, and keep an array of untyped maps whole (#57, #64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,37 @@ empty:
 grep -rn 'constraints == \[\]\|constraints == nil\|Enum.empty?(constraints' lib
 ```
 
+**An array is a separate shape, not a variation of one.** #64 was the same
+data loss one type over: `{:array, :map}` normalises to
+`{:array, Ash.Type.Map}` and puts the element's constraints under `:items`, so
+a guard that reads the top-level list finds nothing and the whole array takes
+the typed path. Whenever you write a condition on `action.returns`, write the
+`{:array, _}` clause at the same time and read `constraints[:items]` in it.
+
+### A fixture that reads one record cannot see a list bug — #57
+
+**Symptom.** The suite is green, the consumer is not. Key casing, field
+selection and metadata all pass here, and an unpaginated read in
+`ash_kotlin_multiplatform` comes back with internal atom keys.
+
+**Why.** Stage 4 dispatches on the *type* it is handed, and a resource module
+carries no cardinality: `ValueFormatter.format/5` unwraps a collection only
+for `{:array, _}`, and `format_resource/4` guards on
+`is_map(value) and not is_struct(value)`. A list matched neither, so it was
+returned untouched. Every RPC fixture in this repo read a single record
+through a `get?` action — the one shape that already worked — so 348 tests
+passed against the bug. The paginated read failed a third way: the page is a
+map, so the envelope formatted, but `:results` is not a field on the resource,
+`ResourceFields.get_field_type_info/2` answered `{nil, []}`, and the records
+inside came back raw.
+
+**What we do.** A read has three result shapes and a fixture has to carry all
+three. `test/support/list_output_resources.ex` declares them on
+`AshIntrospection.Test.LedgerEntry`: `:list_entries` (bare list),
+`:paged_entries` (offset pagination), `:get_entry` (`get?`). Use it, and assert
+the *values* on **every** element — a list whose first record is right and
+whose second is not is invisible to a `List.first/1` assertion.
+
 ### Never call `Ash.DataLayer.Ets.stop/1` in a test — fixed in #55
 
 **Symptom, before the fix.** Roughly one `mix test` run in forty failed on
@@ -368,7 +399,8 @@ at the top of every `.ex`, `.exs` and `.md` file. Markdown uses an HTML comment.
 
 **Why.** `ash_kotlin_multiplatform` calls `AshIntrospection` at 35 sites across
 21 files (measured 2026-09-09) and there is no contract test between the two
-repos. Its `mix.exs` still asks for `~> 0.2.0`, which does not admit 0.3.0.
+repos. Its `mix.exs` asks for `~> 0.3` (line 102, checked 2026-09-10), so it
+takes every 0.3.x release here unreviewed.
 
 **What we do.** Before changing a public function on `Rpc.Pipeline`,
 `Rpc.Request`, `FieldFormatter`, `Helpers`, `TypeSystem.Introspection` or
@@ -390,10 +422,10 @@ mix hex.audit
 mix deps.audit
 ```
 
-`main` is at **348 tests + 1 doctest, 0 failures** (measured 2026-09-10 on the
-#62 branch). A pull request that changes that number
-downward, or that leaves a compiler warning, is not finished. Never suppress a
-warning — fix the cause.
+`main` is at **366 tests + 1 doctest, 0 failures** (measured 2026-09-10 on the
+#57 / #64 branch). A pull request that changes that number downward, or that
+leaves a compiler warning, is not finished. Never suppress a warning — fix the
+cause.
 
 ## Markdown in this repo
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,7 @@ flowchart TB
     dev -->|"writes resources in"| app
     dev -->|"runs mix codegen task"| akm
     app -->|"declares domains and RPC actions for"| akm
-    akm -->|"hex dep: ash_introspection ~> 0.2.0"| ai
+    akm -->|"hex dep: ash_introspection ~> 0.3"| ai
     akm -->|"emits source files"| kclient
     kclient -->|"RPC request over HTTP"| app
     ai -->|"introspects at compile and run time"| ash

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -42,17 +42,28 @@ upstream `437901f` by hand, because upstream's own version of that commit calls
 Discovery scopes to declared entrypoints by action kind: a read, create, update
 or destroy entrypoint keeps the whole resource in scope, a generic action keeps
 only what it names. Upstream is finer — it walks each action's accepted
-attributes, loads and relationship depth — so this repo still over-discovers
-for a resource whose read action exposes fields no client asks for. A partial
-port reads as a closed issue in the log and is not one; #23 carries the rest.
+attributes and follows relationships to their destinations — so this repo
+still over-discovers for a resource whose read action exposes fields no client
+asks for. A partial port reads as a closed issue in the log and is not one; #23
+carries the rest.
+
+`Reachability` does **not** walk `load` statements, whatever an earlier version
+of this page said. `grep load
+deps/ash/lib/ash/info/manifest/generator/reachability.ex` returns two
+`Code.ensure_loaded?/1` calls and nothing else (ash 3.33.1, checked
+2026-09-10). The accepted-attribute walk is real —
+`traverse_action_accepted_attributes/6` at line 208 — and so is the
+relationship traversal at line 116. Do not size #23's port against a
+capability upstream does not have.
 
 ### T2 — One consumer, no contract test
 
-**The risk.** `ash_kotlin_multiplatform` depends on `ash_introspection ~> 0.2.0`
-and calls it at 35 sites across 21 files (measured 2026-09-09). Nothing in
-either repo fails when the shared surface changes shape. The `~> 0.2.0`
-requirement does not even admit the current 0.3.0, so the consumer is pinned
-behind a release that changed the error payload.
+**The risk.** `ash_kotlin_multiplatform` depends on `ash_introspection ~> 0.3`
+(`mix.exs:102`, checked 2026-09-10) and calls it at 35 sites across 21 files
+(measured 2026-09-09). Nothing in either repo fails when the shared surface
+changes shape. The requirement admits every 0.3.x, so the consumer takes each
+release here without review — the opposite exposure to the `~> 0.2.0` pin an
+earlier version of this page described.
 
 **Why it bites.** The 0.3.0 rename of `code` to `type` is exactly the class of
 change a contract test catches and a version constraint does not. It shipped
@@ -82,7 +93,7 @@ yet and is not on the board.
 **The risk.** `lib/ash_introspection/rpc/` had **zero** test coverage until the
 week of 2026-09-09 (#18). Coverage arrived as regression tests attached to the
 seven fixes shipped in 0.3.0 — one test per fixed bug, not a suite that
-describes the pipeline. `main` is at 348 tests, and whole modules
+describes the pipeline. `main` is at 366 tests, and whole modules
 (`value_formatter.ex`, `field_extractor.ex`, `atomizer.ex`) are still exercised
 only incidentally.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,37 @@ which come first. Numbers in parentheses are GitHub issues on
 
 ### Unreleased
 
+- **Format every record of a multi-record read** (#57).
+  `format_output_with_request/3` formatted nothing when the result was a plain
+  list, so an unpaginated read handed the client internal atom keys.
+  `ValueFormatter.format/5` unwraps a collection only when the *type* says
+  `{:array, _}`, and `format_action_output/5` passed the bare resource module,
+  which carries no cardinality. The paginated read was the same fault one level
+  down and had only ever been read off the code: measured on `main` at
+  `51a9c27`, an `%Ash.Page.Offset{}` reaches stage 4 as a map, so the envelope
+  camelized to `hasMore` correctly while every record inside `:results` kept
+  its atom keys, because `:results` is not a field on the resource and
+  `ResourceFields.get_field_type_info/2` answers `{nil, []}`. Both shapes now
+  format; the page's `:results` are formatted first and the envelope after, so
+  nothing is formatted twice. Single-record `get?` reads were always correct,
+  which is why 348 tests stayed green — every RPC fixture read one record.
+  `test/support/list_output_resources.ex` adds the three read shapes.
+  Blocked `ash_kotlin_multiplatform#48`.
+- **Stop nilling the values of a generic action that returns an unconstrained
+  `{:array, :map}`** (#64). The sibling of #62 one type shape over.
+  `unconstrained_map_action?/1` named `Ash.Type.Map` only, so an action
+  returning `{:array, :map}` — which Ash normalises to
+  `{:array, Ash.Type.Map}` with
+  `[items: [preserve_nil_values?: false]]` — fell through to the typed
+  path, which has no field definitions to select against and writes `nil` for
+  every requested name the caller's maps do not use. Measured on `main` at
+  `51a9c27` with a template of `[:id, :name]`,
+  `[%{"_id" => "a-1", "name" => "KSR"}]` reached the client as
+  `[%{id: nil, name: "KSR"}]`. An array's meaningful constraints live under
+  `:items`, so the guard unwraps the tuple and asks
+  `Introspection.has_field_constraints?/1` about the inner keyword list —
+  reading the key rather than comparing the whole list against a literal, as
+  #62 established. Blocked `ash_kotlin_multiplatform#48`.
 - **Stop nilling the payload of a generic action that returns an unconstrained
   `:map`** (#62). `unconstrained_map_action?/1` skips field selection when
   there are no field definitions to select against, and it asked for
@@ -149,8 +180,9 @@ dozen other items.
    the field-name cache declined in #26 would arrive for free, as upstream's
    `Manifest.Custom.formatted_field_names`. It also
    carries the remainder of #21: entrypoint scoping here branches on the action
-   kind, where upstream's `Reachability` walks the accepted attributes, loads
-   and relationship depth of each declared action.
+   kind, where upstream's `Reachability` walks each declared action's accepted
+   attributes and follows its relationships to their destinations. It does not
+   walk `load` statements — see T1 in [risks.md](risks.md) for the grep.
 2. **Correctness fixes that need no manifest**: #40 (second `rescue` in
    `process_single_error` has no `catch` clause), #35 (tuple nested selection
    keys its template from the raw wire name), #16 (a list of errors in

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -828,10 +828,26 @@ defmodule AshIntrospection.Rpc.Pipeline do
   # came back as `nil` per requested field. Ask about `:fields` — the thing the
   # typed path actually needs — and a future ash release adding another default
   # cannot kill the check again.
+  #
+  # #64 is the same silent data loss one type shape over. `{:array, :map}`
+  # normalises to `{:array, Ash.Type.Map}` and puts the element's constraints
+  # under `:items`, so the tuple has to be unwrapped and the inner keyword list
+  # asked the same question. Read `:items` with a `[]` default for the reason
+  # `has_field_constraints?/1` exists: the constraint key is the question, never
+  # the shape of the whole list.
   defp unconstrained_map_action?(action) do
-    action.type == :action && action.returns == Ash.Type.Map &&
-      not Introspection.has_field_constraints?(action.constraints || [])
+    action.type == :action && untyped_map_return?(action.returns, action.constraints || [])
   end
+
+  defp untyped_map_return?(Ash.Type.Map, constraints) do
+    not Introspection.has_field_constraints?(constraints)
+  end
+
+  defp untyped_map_return?({:array, Ash.Type.Map}, constraints) do
+    not Introspection.has_field_constraints?(Keyword.get(constraints, :items, []))
+  end
+
+  defp untyped_map_return?(_returns, _constraints), do: false
 
   defp action_returns_resource?(action) do
     case action.returns do

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -771,11 +771,21 @@ defmodule AshIntrospection.Rpc.Pipeline do
   # resource path for its envelope names. That is not a double pass: the
   # already-formatted list sits under a key the resource does not define, and
   # `format/5` returns any value whose type is `nil` untouched.
+  #
+  # It matches on `:has_more` as well as `:results` because a single record is
+  # also a map here, keyed by the extraction template, and a resource is free
+  # to name an attribute `results`. Both keys come from `ResultProcessor.process/4`,
+  # which sets them on the offset page and the keyset page alike.
   defp format_resource_output(data, resource, formatter, config) when is_list(data) do
     format_value(data, {:array, resource}, formatter, config)
   end
 
-  defp format_resource_output(%{results: results} = page, resource, formatter, config)
+  defp format_resource_output(
+         %{results: results, has_more: _} = page,
+         resource,
+         formatter,
+         config
+       )
        when is_list(results) do
     page
     |> Map.put(:results, format_value(results, {:array, resource}, formatter, config))

--- a/lib/ash_introspection/rpc/pipeline.ex
+++ b/lib/ash_introspection/rpc/pipeline.ex
@@ -757,8 +757,37 @@ defmodule AshIntrospection.Rpc.Pipeline do
     end
   end
 
+  # A read hands stage 4 one of three shapes and only one of them used to
+  # format. `ValueFormatter.format/5` unwraps a collection when the *type* says
+  # `{:array, _}`, and this is the only caller that knows the data is a
+  # collection of `resource`, because a resource module carries no cardinality.
+  # #57: passing the bare module for a list left every record with internal
+  # atom keys, and the paginated page — a map with `:results` — formatted its
+  # own envelope and nothing inside it, since `:results` is not a field on the
+  # resource so `ResourceFields.get_field_type_info/2` answers `{nil, []}`.
+  # Both measured on `main` at `51a9c27`.
+  #
+  # The page clause formats `:results` first and then runs the page through the
+  # resource path for its envelope names. That is not a double pass: the
+  # already-formatted list sits under a key the resource does not define, and
+  # `format/5` returns any value whose type is `nil` untouched.
+  defp format_resource_output(data, resource, formatter, config) when is_list(data) do
+    format_value(data, {:array, resource}, formatter, config)
+  end
+
+  defp format_resource_output(%{results: results} = page, resource, formatter, config)
+       when is_list(results) do
+    page
+    |> Map.put(:results, format_value(results, {:array, resource}, formatter, config))
+    |> format_value(resource, formatter, config)
+  end
+
   defp format_resource_output(data, resource, formatter, config) do
-    ValueFormatter.format(data, resource, [], :output, value_formatter_config(formatter, config))
+    format_value(data, resource, formatter, config)
+  end
+
+  defp format_value(data, type, formatter, config) do
+    ValueFormatter.format(data, type, [], :output, value_formatter_config(formatter, config))
   end
 
   defp format_generic_action_output(data, action, formatter, config) do

--- a/test/ash_introspection/rpc/pipeline_list_output_test.exs
+++ b/test/ash_introspection/rpc/pipeline_list_output_test.exs
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineListOutputTest do
+  @moduledoc """
+  Pins that stage 4 formats a read result carrying more than one record.
+
+  #57: `format_output_with_request/3` formatted nothing when the result was a
+  plain list. `ValueFormatter.format_resource/4` guards on `is_map(value) and
+  not is_struct(value)`, and `format/5` only unwraps an array when the *type*
+  is `{:array, _}` — but `Pipeline.format_action_output/5` hands it the bare
+  resource module. Neither path matched a list, so an unpaginated read returned
+  internal atom keys to the client.
+
+  The paginated read is the same bug one level down and it was only ever
+  read off the code. Measured on `main` at `51a9c27`: an `%Ash.Page.Offset{}`
+  reaches stage 4 as a map, so `format_resource/4` does match and camelizes the
+  envelope — `hasMore` came back correctly — but `:results` is not a field on
+  the resource, so `ResourceFields.get_field_type_info/2` answers `{nil, []}`
+  and every record inside the page came back with atom keys. Both shapes are
+  covered here.
+
+  Single-record `get?` reads were always correct, which is why nothing caught
+  this: every RPC fixture in the suite read one record. `:get_entry` is here as
+  the control.
+
+  The assertions name the values, not just the casing, and they name **every**
+  element. A list whose first record is right and whose second is not is the
+  failure a `List.first/1` assertion cannot see.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.LedgerEntry
+  alias AshIntrospection.Test.ListOutputDomain
+
+  setup do
+    entries =
+      for {name, amount} <- [{"alpha ledger", 10}, {"beta ledger", 20}, {"gamma ledger", 30}] do
+        LedgerEntry
+        |> Ash.Changeset.for_create(:create, %{account_name: name, entry_amount: amount})
+        |> Ash.create!()
+      end
+
+    %{entries: entries}
+  end
+
+  defp response(action_name, overrides \\ %{}) do
+    request =
+      %{
+        domain: ListOutputDomain,
+        resource: LedgerEntry,
+        action: Ash.Resource.Info.action(LedgerEntry, action_name),
+        rpc_action: %{},
+        input: %{},
+        context: %{},
+        select: [:id, :account_name, :entry_amount],
+        load: [],
+        extraction_template: [:id, :account_name, :entry_amount],
+        show_metadata: []
+      }
+      |> Map.merge(overrides)
+      |> Request.new()
+
+    {:ok, ash_result} = Pipeline.execute_ash_action(request)
+    {:ok, processed} = Pipeline.process_result(ash_result, request)
+
+    Pipeline.format_output_with_request(%{success: true, data: processed}, request)
+  end
+
+  describe "an unpaginated read returning several records" do
+    test "formats every record, not the first one" do
+      %{"data" => records} = response(:list_entries)
+
+      assert [alpha, beta, gamma] = records
+
+      assert %{"accountName" => "alpha ledger", "entryAmount" => 10} = alpha
+      assert %{"accountName" => "beta ledger", "entryAmount" => 20} = beta
+      assert %{"accountName" => "gamma ledger", "entryAmount" => 30} = gamma
+    end
+
+    test "leaves no internal atom key anywhere in the list" do
+      %{"data" => records} = response(:list_entries)
+
+      for record <- records do
+        assert Enum.sort(Map.keys(record)) == ["accountName", "entryAmount", "id"]
+      end
+    end
+
+    test "carries each record's id through", %{entries: entries} do
+      %{"data" => records} = response(:list_entries)
+
+      returned_ids = records |> Enum.map(& &1["id"]) |> Enum.sort()
+      assert returned_ids == entries |> Enum.map(& &1.id) |> Enum.sort()
+    end
+
+    test "returns an empty list as an empty list" do
+      LedgerEntry |> Ash.read!() |> Enum.each(&Ash.destroy!/1)
+
+      assert %{"data" => []} = response(:list_entries)
+    end
+  end
+
+  describe "a paginated read" do
+    test "formats the records inside the page, not only the page envelope" do
+      %{"data" => page} = response(:paged_entries, %{pagination: %{limit: 2, offset: 0}})
+
+      assert [alpha, beta] = page["results"]
+      assert %{"accountName" => "alpha ledger", "entryAmount" => 10} = alpha
+      assert %{"accountName" => "beta ledger", "entryAmount" => 20} = beta
+    end
+
+    test "leaves no internal atom key inside the page's records" do
+      %{"data" => page} = response(:paged_entries, %{pagination: %{limit: 3, offset: 0}})
+
+      for record <- page["results"] do
+        assert Enum.sort(Map.keys(record)) == ["accountName", "entryAmount", "id"]
+      end
+    end
+
+    test "keeps the page envelope it already formatted" do
+      %{"data" => page} = response(:paged_entries, %{pagination: %{limit: 2, offset: 0}})
+
+      assert page["limit"] == 2
+      assert page["offset"] == 0
+      assert page["hasMore"] == true
+    end
+
+    test "formats the second page's records too" do
+      %{"data" => page} = response(:paged_entries, %{pagination: %{limit: 2, offset: 2}})
+
+      assert [gamma] = page["results"]
+      assert %{"accountName" => "gamma ledger", "entryAmount" => 30} = gamma
+    end
+  end
+
+  describe "the single-record path #57 never broke" do
+    test "a get? read still formats its one record", %{entries: [alpha | _]} do
+      %{"data" => record} =
+        response(:get_entry, %{get_by: %{account_name: "alpha ledger"}})
+
+      assert record["id"] == alpha.id
+      assert record["accountName"] == "alpha ledger"
+      assert record["entryAmount"] == 10
+    end
+  end
+end

--- a/test/ash_introspection/rpc/pipeline_unconstrained_map_array_test.exs
+++ b/test/ash_introspection/rpc/pipeline_unconstrained_map_array_test.exs
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.PipelineUnconstrainedMapArrayTest do
+  @moduledoc """
+  Pins that a generic action returning an unconstrained `{:array, :map}` hands
+  every one of its maps to the client untouched.
+
+  This is #64, the sibling of #62 one type shape over. `unconstrained_map_action?/1`
+  named `Ash.Type.Map` only, so an action returning `{:array, :map}` — which
+  Ash normalises to `{:array, Ash.Type.Map}` with
+  `[items: [preserve_nil_values?: false]]` — fell through to the typed path.
+  That path has no field definitions to select against, so it wrote `nil` for
+  every requested name the caller's maps do not use. Measured on `main` at
+  `51a9c27` with an extraction template of `[:id, :name]`:
+
+      [%{"_id" => "a-1", "name" => "KSR"}]  ->  [%{id: nil, name: "KSR"}]
+
+  `_id` is gone and `id` is `nil` — silent data loss, not a re-keying nit.
+
+  The array's meaningful constraints live under `:items`, so the guard has to
+  unwrap the tuple and ask `has_field_constraints?/1` about the inner keyword
+  list. Asking about `:fields` rather than comparing a whole keyword list
+  against a literal is the #62 lesson; `CLAUDE.md` carries it and a grep keeps
+  it.
+
+  `:typed_rows` is the control: the same `{:array, :map}` shape carrying real
+  `items: [fields: ...]` constraints, which must keep going through the typed
+  path and keep being formatted.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.LedgerEntry
+  alias AshIntrospection.Test.ListOutputDomain
+  alias AshIntrospection.TypeSystem.Introspection
+
+  @raw_rows [
+    %{"_id" => "a-1", "name" => "KSR", "nested" => %{"_rev" => "rev-1"}},
+    %{"_id" => "a-2", "name" => "Ivy", "nested" => %{"_rev" => "rev-2"}}
+  ]
+
+  defp response(action_name, extraction_template) do
+    request =
+      %{
+        domain: ListOutputDomain,
+        resource: LedgerEntry,
+        action: Ash.Resource.Info.action(LedgerEntry, action_name),
+        rpc_action: %{},
+        input: %{},
+        context: %{},
+        select: [],
+        load: [],
+        extraction_template: extraction_template,
+        show_metadata: []
+      }
+      |> Request.new()
+
+    {:ok, ash_result} = Pipeline.execute_ash_action(request)
+    {:ok, processed} = Pipeline.process_result(ash_result, request)
+
+    Pipeline.format_output_with_request(%{success: true, data: processed}, request)
+  end
+
+  describe "the premise" do
+    test "ash normalises an array-of-map action to a tuple type with :items constraints" do
+      action = Ash.Resource.Info.action(LedgerEntry, :raw_rows)
+
+      assert action.returns == {:array, Ash.Type.Map}
+      assert action.constraints == [items: [preserve_nil_values?: false]]
+      refute Introspection.has_field_constraints?(action.constraints)
+      refute Introspection.has_field_constraints?(Keyword.get(action.constraints, :items))
+    end
+
+    test "a constrained array-of-map does carry :fields under :items" do
+      action = Ash.Resource.Info.action(LedgerEntry, :typed_rows)
+
+      assert Introspection.has_field_constraints?(Keyword.get(action.constraints, :items))
+    end
+  end
+
+  describe "a generic action returning an unconstrained array of maps" do
+    test "hands every row back whole when the client asks for names they do not carry" do
+      assert %{"data" => @raw_rows, "success" => true} = response(:raw_rows, [:id, :name])
+    end
+
+    test "writes no nil into any row" do
+      %{"data" => rows} = response(:raw_rows, [:id, :name])
+
+      assert [first, second] = rows
+      assert first["_id"] == "a-1"
+      assert first["name"] == "KSR"
+      assert second["_id"] == "a-2"
+      assert second["name"] == "Ivy"
+      refute Enum.any?(rows, &Map.has_key?(&1, :id))
+      refute Enum.any?(rows, &Enum.any?(&1, fn {_key, value} -> is_nil(value) end))
+    end
+
+    test "keeps the caller's keys in every row, leading underscore included" do
+      %{"data" => rows} = response(:raw_rows, [:id, :name])
+
+      for row <- rows do
+        assert Enum.sort(Map.keys(row)) == ["_id", "name", "nested"]
+      end
+    end
+
+    test "leaves nested keys alone in every row" do
+      %{"data" => rows} = response(:raw_rows, [:id, :name])
+
+      assert Enum.map(rows, & &1["nested"]) == [%{"_rev" => "rev-1"}, %{"_rev" => "rev-2"}]
+    end
+
+    test "hands the rows back when the client asks for the maps' own keys" do
+      assert %{"data" => @raw_rows} = response(:raw_rows, [:_id, :name, :nested])
+    end
+
+    test "hands the rows back when the client asks for nothing" do
+      assert %{"data" => @raw_rows} = response(:raw_rows, [])
+    end
+  end
+
+  describe "a generic action returning a constrained array of maps" do
+    test "still goes through the typed path and formats every row" do
+      %{"data" => rows} = response(:typed_rows, [:row_id, :row_label])
+
+      assert rows == [
+               %{"rowId" => "t-1", "rowLabel" => "first"},
+               %{"rowId" => "t-2", "rowLabel" => "second"}
+             ]
+    end
+  end
+end

--- a/test/support/list_output_resources.ex
+++ b/test/support/list_output_resources.ex
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.ListOutputDomain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource(AshIntrospection.Test.LedgerEntry)
+  end
+end
+
+defmodule AshIntrospection.Test.LedgerEntry do
+  @moduledoc """
+  Resource for exercising stage 4 on results that are **more than one record**.
+
+  Every other RPC fixture here reads a single record through a `get?` action,
+  which is exactly the shape `ValueFormatter.format_resource/4` already
+  matched, so #57 — a plain list reaching the client with internal atom keys —
+  survived a full test suite. This resource carries the three read shapes stage
+  4 has to tell apart:
+
+  - `:list_entries` is an ordinary read, so the result is a bare list.
+  - `:paged_entries` requires offset pagination, so the result is an
+    `%Ash.Page.Offset{}` that stage 3 flattens into a map with `:results`.
+  - `:get_entry` is the single-record `get?` read, here as the control that
+    proves the path which always worked still works.
+
+  Attribute names are snake_case (`account_name`, `entry_amount`) so a missing
+  format pass is visible as an atom key, and the values are distinct per record
+  so a test can assert that each one survived rather than only that the first
+  one is shaped right.
+
+  `:raw_rows` is #64: a generic action returning an unconstrained
+  `{:array, :map}`. Its maps carry the caller's own keys — a leading
+  underscore (`_id`) and a snake_case word (`field_name`) — which the typed
+  path rewrites or nils out.  `:typed_rows` is its control: the same array
+  shape with real `items: [fields: ...]` constraints, which must keep going
+  through the typed path.
+
+  `private? true` on the ETS table for the reason `Test.Account` has it — see
+  #55 and the note in `CLAUDE.md`. Writes must stay in the test process.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.ListOutputDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  @raw_rows [
+    %{"_id" => "a-1", "name" => "KSR", "nested" => %{"_rev" => "rev-1"}},
+    %{"_id" => "a-2", "name" => "Ivy", "nested" => %{"_rev" => "rev-2"}}
+  ]
+
+  ets do
+    private?(true)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:account_name, :string, allow_nil?: false, public?: true)
+    attribute(:entry_amount, :integer, allow_nil?: false, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      primary?(true)
+      accept([:account_name, :entry_amount])
+    end
+
+    read :list_entries do
+      prepare(build(sort: [entry_amount: :asc]))
+    end
+
+    read :paged_entries do
+      pagination(offset?: true, required?: true, default_limit: 10, countable: true)
+      prepare(build(sort: [entry_amount: :asc]))
+    end
+
+    read :get_entry do
+      get?(true)
+    end
+
+    action :raw_rows, {:array, :map} do
+      run(fn _input, _context -> {:ok, AshIntrospection.Test.LedgerEntry.raw_rows()} end)
+    end
+
+    action :typed_rows, {:array, :map} do
+      constraints(items: [fields: [row_id: [type: :string], row_label: [type: :string]]])
+
+      run(fn _input, _context ->
+        {:ok, [%{row_id: "t-1", row_label: "first"}, %{row_id: "t-2", row_label: "second"}]}
+      end)
+    end
+  end
+
+  @doc "The untyped rows `:raw_rows` hands back, keys and all."
+  def raw_rows, do: @raw_rows
+end


### PR DESCRIPTION
Closes #57
Closes #64

Two bugs with one shape: **a list of things is not handled the way a single
thing is**, and both live in the output-formatting path. #64's issue said it
would collide with #57, so they ship together.

## #57 — a multi-record read reached the client unformatted

`format_output_with_request/3` formatted nothing when the result was a plain
list. `ValueFormatter.format/5` unwraps a collection only when the *type* says
`{:array, _}`, and `Pipeline.format_action_output/5` passed the bare resource
module, which carries no cardinality; `format_resource/4` in turn guards on
`is_map(value) and not is_struct(value)`. A list matched neither path, so an
unpaginated read handed back internal atom keys.

Single-record `get?` reads were always correct. Every RPC fixture in the repo
read one record, so 348 tests passed against the bug.

### The paginated read was affected too — measured, not read off the code

The issue comment flagged this as code-read only, because the fixtures had no
paginated action. There is one now (`LedgerEntry.paged_entries`, offset
pagination). Measured on `main` at `51a9c27`, an unfixed run returns:

```elixir
%{
  "data" => %{
    "hasMore" => true, "limit" => 2, "offset" => 0, "count" => nil,
    "results" => [
      %{id: "1fa86b4f-…", account_name: "alpha ledger", entry_amount: 10},
      %{id: "d11f31c7-…", account_name: "beta ledger",  entry_amount: 20}
    ]
  },
  "success" => true
}
```

The prediction holds exactly. An `%Ash.Page.Offset{}` reaches stage 4 as a map,
so `format_resource/4` *does* match and the envelope camelizes correctly —
`hasMore` is right. But `:results` is not a field on the resource, so
`ResourceFields.get_field_type_info/2` answers `{nil, []}` and every record
inside the page comes back raw. A fix that only added a top-level list clause
would have left this broken.

### The fix

`format_resource_output/4` now dispatches on the shape it is handed: a list is
formatted as `{:array, resource}`; a page has its `:results` formatted first and
its envelope after. That is not a double pass — the already-formatted list sits
under a key the resource does not define, and `format/5` returns any value whose
type is `nil` untouched. The page clause matches on `:has_more` as well as
`:results`, so a single record carrying an attribute named `results` cannot hit
it.

## #64 — an array of untyped maps lost its values

`unconstrained_map_action?/1` named `Ash.Type.Map` only. A generic action
returning `{:array, :map}` normalises to `{:array, Ash.Type.Map}` with
`[items: [preserve_nil_values?: false]]`, so it fell through to the typed path,
which has no field definitions to select against and writes `nil` for every
requested name the caller's maps do not use. Measured on `main` at `51a9c27`
with a template of `[:id, :name]`:

```
[%{"_id" => "a-1", "name" => "KSR"}]  ->  [%{id: nil, name: "KSR"}]
```

An array's meaningful constraints live under `:items`, so the guard unwraps the
tuple and asks `Introspection.has_field_constraints?/1` about the inner keyword
list. It reads the constraint key rather than comparing a whole keyword list
against a literal — the #62 lesson, now in `CLAUDE.md`. The grep that lesson
names still returns nothing:

```
grep -rn 'constraints == \[\]\|constraints == nil\|Enum.empty?(constraints' lib
```

## Tests

Both suites were written failing first and each failure was confirmed against
`main` for the right reason: 6 of 9 in the #57 file, 5 of 9 in the #64 file. The
three and four that already passed are the regression pins — the single-record
`get?` control, the page envelope, the empty list, and the typed-array control.

Per the #62 lesson, the assertions name the **values**, not the casing, and they
name **every** element of a multi-record result. #64's assert that the keys
inside the untyped maps — `_id`, `nested._rev` — are not rewritten, and that no
row carries a `nil`.

New fixture in a new file, `test/support/list_output_resources.ex`
(`AshIntrospection.Test.LedgerEntry`, private ETS table per #55). It carries the
three read shapes stage 4 has to tell apart — bare list, offset page,
single-record `get?` — plus the untyped and typed `{:array, :map}` actions.

`348 tests + 1 doctest` → `366 tests + 1 doctest`, 0 failures.

## Documentation

`CLAUDE.md` requires a behaviour change to update `docs/` in the same PR.

- `docs/roadmap.md`: #57 and #64 moved into Shipped / Unreleased.
- **Correction — `Reachability` does not walk `load` statements.** T1 in
  `docs/risks.md` said upstream's
  `Ash.Info.Manifest.Generator.Reachability` walks "accepted attributes, loads
  and relationship depth", and `docs/roadmap.md` repeated it under #23. Verified
  before editing: `grep load
  deps/ash/lib/ash/info/manifest/generator/reachability.ex` returns two
  `Code.ensure_loaded?/1` calls and nothing else (ash 3.33.1). The
  accepted-attribute walk (`traverse_action_accepted_attributes/6`, line 208)
  and the relationship traversal (line 116) are real and stay. Agents read these
  pages as ground truth and were sizing #23's port against a capability upstream
  does not have.
- **Correction — the consumer asks for `~> 0.3`, not `~> 0.2.0`.** Verified at
  `ash_kotlin_multiplatform` `mix.exs:102`. The old text had the exposure
  backwards: the consumer is not pinned behind 0.3.0, it takes every 0.3.x
  release here unreviewed. Fixed in T2 of `docs/risks.md`, the C4 container
  diagram in `docs/architecture.md`, and `CLAUDE.md`.
- Two new `CLAUDE.md` lessons: an array return type is a separate shape from its
  element type, and a fixture that reads one record cannot see a list bug.

## Why this matters downstream

`ash_kotlin_multiplatform#48` is blocked on both. It tried switching
`Runner.run_action/4` to `format_output_with_request/3` and got **14 of 138**
tests failing, with #57 the dominant cause. Landing these unblocks that switch.

## Test plan

All five CI gates run locally on this branch:

| Gate | Result |
| --- | --- |
| `mix format --check-formatted` | pass |
| `mix compile --warnings-as-errors` | pass, no warnings |
| `mix test` | 366 tests + 1 doctest, 0 failures |
| `mix hex.audit` | No retired packages found |
| `mix deps.audit` | No vulnerabilities found |
