### PR TITLE
fix: two inconsistently-handled shapes in field_selector (#35, #45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,62 @@ sites. See `test/ash_introspection/rpc/load_restrictions_test.exs`.
 **They are not authorization.** Ash policies apply to every load that gets
 through. Say so in anything you write about them; risk T5 in
 [`docs/risks.md`](docs/risks.md) explains why it matters.
+
+### A template entry has three shapes, each with its own reader — #35
+
+**Symptom.** A field you selected is missing from the response, or arrives
+`nil`, and nothing errors. Selecting the same field a different way works.
+
+**Why.** `FieldSelector` emits three entry shapes and each consumer matches
+only some of them:
+
+| Entry | Meaning | Matched by |
+| --- | --- | --- |
+| `:name` | a plain field | `ResultProcessor`, every extractor |
+| `{:name, nested}` | a nested selection | `ResultProcessor`, atom key only |
+| `%{field_name: :name, index: n}` | a tuple position | `FieldExtractor.convert_tuple_to_map/2` and `ResultProcessor` |
+
+Every consumer ends its `case` with a catch-all that returns the accumulator
+untouched, so an entry no clause matches is dropped in silence. In #35 the
+tuple `{:nested, ...}` branch emitted `{"corner", nested}` with the raw wire
+name; `ResultProcessor` matches `{field_atom, nested} when is_atom(field_atom)`,
+so the field vanished from the response while the same field selected flat came
+back whole.
+
+**What we do.** Resolve the atom before you build an entry — never key a
+template from the wire name. And when you add a shape, add the clause that
+reads it in the same change; a shape nothing matches fails as missing data, not
+as an error. #66 is what is left of this: a nested entry carries no index, so
+`convert_tuple_to_map/2` cannot place a nested tuple field and the value comes
+back `nil`. See
+`test/ash_introspection/rpc/field_processing/field_selector_tuple_nested_test.exs`.
+
+### `a || b` yields `b` when both are falsy, so `||` erases one key — #45
+
+**Symptom.** A request behaves one way with atom keys and another way with
+string keys, and the two spellings are supposed to be the same request.
+
+**Why.** `Map.get(m, :k) || Map.get(m, "k")` is the #15 shape and it answers
+truthiness where the question is presence. The half that is easy to miss is
+which side loses: `||` returns its **right** operand when both are falsy, so
+`%{"k" => false}` yields `false` and `%{k: false}` yields `nil`. Measured on
+`main` at `b99e5a3` in `get_args_and_fields/1`: `%{"slug" => %{fields: false}}`
+loaded the calculation and dropped the selection, while
+`%{"slug" => %{"fields" => false}}` rejected it.
+
+**What we do.** `Map.fetch/2` on the atom key, then the string key —
+`plain_map_field/2` in `result_processor.ex` and `fetch_either_key/2` in
+`field_selector.ex` are the two copies of the shape. Both key forms reach the
+library: the atom form is why `atomize_nested_value/3` carries `%{args: _}` and
+`%{fields: _}` clauses alongside the string ones. This grep must stay empty:
+
+```
+grep -rn 'Map.get(\w*, :\w*) || Map.get(\w*, "' lib
+```
+
+`lib/ash_introspection/rpc/error.ex:68` is not this shape — it prefers
+`:fields` over a differently named `:field`, and both are atoms.
+
 ### An upstream fix that hangs off a Spark extension cannot be ported here
 
 **Symptom.** You start porting an `ash_typescript` commit, reach for
@@ -422,10 +478,10 @@ mix hex.audit
 mix deps.audit
 ```
 
-`main` is at **366 tests + 1 doctest, 0 failures** (measured 2026-09-10 on the
-#57 / #64 branch). A pull request that changes that number downward, or that
-leaves a compiler warning, is not finished. Never suppress a warning — fix the
-cause.
+`main` is at **359 tests + 1 doctest, 0 failures** (measured 2026-09-10 at
+`e16e5dc`, after #27 deleted the tests of the dead code it removed). A pull
+request that changes that number downward, or that leaves a compiler warning,
+is not finished. Never suppress a warning — fix the cause.
 
 ## Markdown in this repo
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,6 +31,33 @@ which come first. Numbers in parentheses are GitHub issues on
   classification tags. `Rpc.Pipeline`'s moduledoc no longer claims a
   `parse_request/3` this repo does not implement, and no longer lists
   `discover_action` in its example config, which nothing here reads.
+- **Key a nested tuple selection from the resolved atom** (#35, `24e7773`).
+  The `{:nested, ...}` branch of `FieldSelector.select_tuple_fields/4` built
+  its extraction template from the raw wire name while every sibling branch
+  used the resolved atom. `ResultProcessor` matches a nested entry as
+  `{atom, nested}`, so the string key fell through its catch-all and the field
+  vanished from the response. Measured on `main` at `b99e5a3` against a tuple
+  of `{label :: string, corner :: map(x, y)}`: `["label", "corner"]` returned
+  both fields, `[%{"corner" => ["x", "y"]}]` returned `%{}`, and the
+  multi-entry spelling of the same request returned `%{"corner" => nil}` —
+  three answers to one request. `test/support/tuple_selection_resources.ex` is
+  the first tuple fixture with a nested-selectable field; `Test.Post.get_bounds`
+  carries two floats, so the branch had no coverage at all. The value still
+  does not survive, because a nested entry carries no tuple index: that is #66,
+  pinned by an assertion in the new test.
+- **Read the calculation envelope keys by presence, not truthiness** (#45,
+  `14d806e`). `get_args_and_fields/1` kept the
+  `Map.get(m, :args) || Map.get(m, "args")` shape that #15 removed from
+  `result_processor`. Latent for data, as the issue said — `:args` is a map
+  and `:fields` is a list, and neither `%{}` nor `[]` is falsy — but not
+  inert: `||` returns its right operand when both sides are falsy, so a
+  present-and-`false` value survived under the string key and was erased under
+  the atom key. Measured on `main` at `b99e5a3`, `%{"slug" => %{fields:
+  false}}` loaded the calculation and dropped the selection while
+  `%{"slug" => %{"fields" => false}}` rejected it. `Map.fetch/2` before the
+  string key, in the style of `plain_map_field/2`. `nil` keeps its meaning: a
+  JSON `null` under `:args` is "no arguments", so the `not is_nil/1` guard
+  stays and both null cases answer as they did before.
 - **Format every record of a multi-record read** (#57).
   `format_output_with_request/3` formatted nothing when the result was a plain
   list, so an unpaginated read handed the client internal atom keys.
@@ -198,8 +225,9 @@ dozen other items.
    attributes and follows its relationships to their destinations. It does not
    walk `load` statements — see T1 in [risks.md](risks.md) for the grep.
 2. **Correctness fixes that need no manifest**: #40 (second `rescue` in
-   `process_single_error` has no `catch` clause), #35 (tuple nested selection
-   keys its template from the raw wire name), #16 (a list of errors in
+   `process_single_error` has no `catch` clause), #66 (a nested selection
+   inside a tuple field returns `nil`, because the template entry carries no
+   tuple index — filed out of #35), #16 (a list of errors in
    `build_error_response/1` for bulk actions), #17 (unwrap Reactor step errors,
    serialize `Ash.Type.Vector`).
 3. **#18 — the RPC test floor.** Coverage arrives with each fix by preference,
@@ -209,8 +237,7 @@ dozen other items.
    `FieldSelector` clauses #19 just guarded: a relationship loaded through an
    `%Ash.Query{}` envelope is a seventh append site and needs its own
    `check_load_allowed!/3`.
-5. **Housekeeping**: #45 (the remaining `||` key-lookup pattern in
-   `field_selector`), #39 (README wrapping — half of it, the test-domain
+5. **Housekeeping**: #39 (README wrapping — half of it, the test-domain
    warning, is already fixed in `config/test.exs`).
 
 ## Decided against

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -733,7 +733,12 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
               {_nested_select, _nested_load, nested_template} =
                 select_fields(field_type, field_constraints, nested_fields, new_path, config)
 
-              {select, load, template ++ [{field_name, nested_template}]}
+              # `field_atom`, never `field_name`. `ResultProcessor` matches a
+              # nested template entry as `{atom, nested}`, so the raw wire name
+              # fell through its catch-all and the field vanished from the
+              # response, while the same field asked for flat came back. See
+              # #35.
+              {select, load, template ++ [{field_atom, nested_template}]}
             else
               throw({:unknown_field, field_atom, "tuple", path})
             end

--- a/lib/ash_introspection/rpc/field_processing/field_selector.ex
+++ b/lib/ash_introspection/rpc/field_processing/field_selector.ex
@@ -1049,29 +1049,44 @@ defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelector do
 
   defp atomize_nested_value(value, _resource, _config), do: value
 
+  # A calculation envelope names `:args` and `:fields` under either key form:
+  # a wire request carries strings, an internally built request carries atoms.
+  # `nil` under `:args` is a JSON `null` and means "no arguments", so it is not
+  # a with-args request; a `:fields` key is a field selection whatever it
+  # holds, and a value that is not a list is rejected downstream rather than
+  # dropped here.
   defp get_args_and_fields(map) when is_map(map) do
-    args = Map.get(map, :args) || Map.get(map, "args")
-    has_fields_key = Map.has_key?(map, :fields) || Map.has_key?(map, "fields")
+    fields = fetch_either_key(map, :fields)
 
-    cond do
-      args != nil ->
-        fields =
-          cond do
-            Map.has_key?(map, :fields) -> Map.get(map, :fields)
-            Map.has_key?(map, "fields") -> Map.get(map, "fields")
-            true -> nil
-          end
+    case fetch_either_key(map, :args) do
+      {:ok, args} when not is_nil(args) ->
+        {:ok, args, fetched_value(fields)}
 
-        {:ok, args, fields}
-
-      has_fields_key ->
-        fields = Map.get(map, :fields) || Map.get(map, "fields")
-        {:ok, nil, fields}
-
-      true ->
-        :not_args_structure
+      _ ->
+        case fields do
+          {:ok, value} -> {:ok, nil, value}
+          :error -> :not_args_structure
+        end
     end
   end
+
+  # `Map.fetch/2` before the string key, never
+  # `Map.get(map, key) || Map.get(map, to_string(key))`. `||` answers
+  # truthiness where the question is presence: it erases a key that is present
+  # and `false`, and — because it returns its right operand when both sides
+  # are falsy — it erases it only under the atom key, so one request got two
+  # answers depending on which form the caller built. Same reasoning and same
+  # shape as `plain_map_field/2` in `ResultProcessor`, which is where #15 fixed
+  # it for record fields. See #45.
+  defp fetch_either_key(map, key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, to_string(key))
+    end
+  end
+
+  defp fetched_value({:ok, value}), do: value
+  defp fetched_value(:error), do: nil
 
   defp resolve_resource_field_name(resource, field_name, config) when is_binary(field_name) do
     if is_interop_resource?(resource, config) do

--- a/test/ash_introspection/rpc/field_processing/field_selector_args_key_lookup_test.exs
+++ b/test/ash_introspection/rpc/field_processing/field_selector_args_key_lookup_test.exs
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelectorArgsKeyLookupTest do
+  @moduledoc """
+  Issue #45: `get_args_and_fields/1` read its two keys with
+  `Map.get(map, :args) || Map.get(map, "args")`, the shape that made #15 a
+  data-corruption bug. `||` cannot tell a key that is present and falsy from a
+  key that is absent.
+
+  For data the issue's "latent" verdict holds: `:args` is a map and `:fields`
+  is a list, and neither `%{}` nor `[]` is falsy, so no well-formed request
+  loses a value. The idiom is not inert, though. `||` returns its *right*
+  operand when both sides are falsy, so a present-and-`false` value survives
+  under the string key and is erased under the atom key. Measured on `main` at
+  `b99e5a3` against `Test.LoadRestrictions.Article`, whose `:slug` calculation
+  takes no arguments and returns a plain string:
+
+      %{"slug" => %{fields: false}}     -> {:ok, ...}   loaded, selection dropped
+      %{"slug" => %{"fields" => false}} -> {:error, {:invalid_field_selection,
+                                            :slug, :calculation, []}}
+
+  One request, two answers, decided by which key form the caller happened to
+  build. Both forms reach here — the atom form is why `atomize_nested_value/3`
+  carries `%{args: _}` and `%{fields: _}` clauses alongside the string ones.
+
+  `Map.fetch/2` before falling back to the string key answers presence rather
+  than truthiness, in the style of `plain_map_field/2` in `ResultProcessor`.
+  The two spellings now agree everywhere: `fields: false` is rejected under
+  both, and `args: false` takes the with-args path under both and is handed to
+  Ash as written, which is what the string form already did.
+
+  `nil` keeps its own meaning. A JSON `null` under `:args` says "no
+  arguments", not "arguments I could not name", so the `not is_nil/1` guard
+  stays and those two cases answer exactly as they did before.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
+  alias AshIntrospection.Test.LoadRestrictions.Article
+
+  defp process(fields), do: FieldSelector.process(Article, :read, fields)
+
+  describe "a well-formed request is untouched" do
+    test "a calculation with arguments still loads with its arguments" do
+      assert {:ok, {[:id], [prefixed_title: %{"prefix" => "re: "}], [:id, :prefixed_title]}} =
+               process(["id", %{"prefixedTitle" => %{"args" => %{"prefix" => "re: "}}}])
+    end
+
+    test "the atom key form gives the same answer as the string key form" do
+      assert process(["id", %{"prefixedTitle" => %{"args" => %{"prefix" => "re: "}}}]) ==
+               process(["id", %{"prefixedTitle" => %{args: %{"prefix" => "re: "}}}])
+    end
+
+    test "an empty :args alongside :fields still resolves both" do
+      assert {:ok, {[:id], [computed_meta: {%{}, [:label]}], [:id, {:computed_meta, [:label]}]}} =
+               process(["id", %{"computedMeta" => %{"args" => %{}, "fields" => ["label"]}}])
+    end
+
+    test "a bare :fields selection still resolves" do
+      assert {:ok, {[:id], [computed_meta: [:label]], [:id, {:computed_meta, [:label]}]}} =
+               process(["id", %{"computedMeta" => %{"fields" => ["label"]}}])
+    end
+
+    test "a map naming neither key is not read as a calculation envelope" do
+      # `:not_args_structure`, so the map goes down the nested-field path and
+      # fails there — not with an argument error.
+      assert {:error, {:unsupported_field_combination, :relationship, :computed_meta, _, []}} =
+               process(["id", %{"computedMeta" => %{"label" => nil}}])
+    end
+  end
+
+  describe "a key that is present and falsy" do
+    test "an atom-keyed :fields is read as present, not as absent" do
+      assert {:error, {:invalid_field_selection, :slug, :calculation, []}} =
+               process(["id", %{"slug" => %{fields: false}}])
+    end
+
+    test "both key forms of :fields give the same answer" do
+      assert process(["id", %{"slug" => %{fields: false}}]) ==
+               process(["id", %{"slug" => %{"fields" => false}}])
+    end
+
+    test "both key forms of :args give the same answer" do
+      assert process(["id", %{"prefixedTitle" => %{args: false}}]) ==
+               process(["id", %{"prefixedTitle" => %{"args" => false}}])
+    end
+
+    test "an atom-keyed :args is read as present, not as absent" do
+      assert {:ok, {[:id], [prefixed_title: false], [:id, :prefixed_title]}} =
+               process(["id", %{"prefixedTitle" => %{args: false}}])
+    end
+  end
+
+  describe "an explicit null keeps its old meaning" do
+    test "a null :args is not a with-args request" do
+      assert {:error, {:invalid_calculation_args, :slug, []}} =
+               process(["id", %{"slug" => %{"args" => nil}}])
+    end
+
+    test "a null :fields on a plain calculation loads it plainly" do
+      assert {:ok, {[:id], [:slug], [:id, :slug]}} =
+               process(["id", %{"slug" => %{"fields" => nil}}])
+    end
+  end
+end

--- a/test/ash_introspection/rpc/field_processing/field_selector_tuple_nested_test.exs
+++ b/test/ash_introspection/rpc/field_processing/field_selector_tuple_nested_test.exs
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Rpc.FieldProcessing.FieldSelectorTupleNestedTest do
+  @moduledoc """
+  Issue #35: the `{:nested, ...}` branch of
+  `FieldSelector.select_tuple_fields/4` keyed its extraction template from the
+  raw wire name while every sibling branch keyed it from the resolved atom.
+
+  The issue asked for a test before a fix, because the inconsistency might have
+  produced the same output either way. It does not. Measured on `main` at
+  `b99e5a3` against `Test.MapTile.get_tile`, a tuple of
+  `{label :: string, corner :: map(x, y)}` holding `{"north-west", %{x: 1.5,
+  y: 2.5}}`:
+
+      ["label", "corner"]          -> %{"corner" => %{"x" => 1.5, "y" => 2.5},
+                                        "label" => "north-west"}
+      [%{"corner" => ["x", "y"]}]  -> %{}
+
+  The nested request lost the field entirely. `ResultProcessor` matches a
+  nested template entry as `{field_atom, nested_template} when is_atom(...)`,
+  so a string key fell through its catch-all and nothing was written. The same
+  field asked for through the `{:multi_nested, ...}` branch — which already
+  resolved the atom — came back as `%{"corner" => nil}`, so two spellings of
+  one request gave three different answers.
+
+  Fixing the key makes the two nested spellings agree. It does **not** make
+  either return the value: a nested entry carries no tuple index, and
+  `FieldExtractor.convert_tuple_to_map/2` can only place a field it has an
+  index for. That gap is #66; the last test here pins the `nil` so the fix for
+  it has to come back and change this file.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshIntrospection.Rpc.FieldProcessing.FieldSelector
+  alias AshIntrospection.Rpc.Pipeline
+  alias AshIntrospection.Rpc.Request
+  alias AshIntrospection.Test.MapTile
+  alias AshIntrospection.Test.TupleSelectionDomain
+
+  defp select(requested_fields) do
+    assert {:ok, {select, load, template}} =
+             FieldSelector.process(MapTile, :get_tile, requested_fields)
+
+    {select, load, template}
+  end
+
+  defp template(requested_fields) do
+    {_select, _load, template} = select(requested_fields)
+    template
+  end
+
+  defp response(requested_fields) do
+    {select, load, template} = select(requested_fields)
+
+    request =
+      %{
+        domain: TupleSelectionDomain,
+        resource: MapTile,
+        action: Ash.Resource.Info.action(MapTile, :get_tile),
+        rpc_action: %{},
+        input: %{},
+        context: %{},
+        select: select,
+        load: load,
+        extraction_template: template,
+        show_metadata: []
+      }
+      |> Request.new()
+
+    {:ok, ash_result} = Pipeline.execute_ash_action(request)
+    {:ok, processed} = Pipeline.process_result(ash_result, request)
+
+    Pipeline.format_output_with_request(%{success: true, data: processed}, request)
+  end
+
+  describe "the premise" do
+    test "a flat selection carries the resolved atom and the tuple index" do
+      assert template(["label", "corner"]) == [
+               %{field_name: :label, index: 0},
+               %{field_name: :corner, index: 1}
+             ]
+    end
+
+    test "a flat selection returns both fields of the tuple" do
+      assert %{"data" => data, "success" => true} = response(["label", "corner"])
+      assert data == %{"label" => "north-west", "corner" => %{"x" => 1.5, "y" => 2.5}}
+    end
+  end
+
+  describe "a nested selection on a tuple field" do
+    test "keys its template from the resolved atom, not the wire name" do
+      assert [{:corner, [:x, :y]}] = template([%{"corner" => ["x", "y"]}])
+    end
+
+    test "keys it the same way the multi-entry spelling does" do
+      single = template([%{"corner" => ["x"]}])
+      multi = template([%{"corner" => ["x"], "label" => nil}])
+
+      assert [{:corner, [:x]}] = single
+      assert {:corner, [:x]} in multi
+    end
+
+    test "still rejects a nested field the tuple field does not have" do
+      assert {:error, {:unknown_field, _, _, [:corner]}} =
+               FieldSelector.process(MapTile, :get_tile, [%{"corner" => ["z"]}])
+    end
+  end
+
+  describe "the gap this fix does not close (#66)" do
+    # A nested template entry has no tuple index, so
+    # `FieldExtractor.convert_tuple_to_map/2` cannot place the field and the
+    # value is lost. Before #35 the key was a string and the field vanished
+    # from the response; now it is present and `nil`. Change this assertion
+    # when #66 lands — do not delete it.
+    test "the value does not survive: the field comes back nil" do
+      assert %{"data" => data} = response(["label", %{"corner" => ["x"]}])
+      assert data == %{"label" => "north-west", "corner" => nil}
+    end
+  end
+end

--- a/test/support/tuple_selection_resources.ex
+++ b/test/support/tuple_selection_resources.ex
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 ash_introspection contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshIntrospection.Test.TupleSelectionDomain do
+  @moduledoc false
+  use Ash.Domain
+
+  resources do
+    resource(AshIntrospection.Test.MapTile)
+  end
+end
+
+defmodule AshIntrospection.Test.MapTile do
+  @moduledoc """
+  Fixture for #35: a tuple whose fields are themselves selectable.
+
+  `Test.Post.get_bounds` — the only tuple action in the suite before this —
+  carries two floats, so no field on it can take a nested spec and the
+  `{:nested, ...}` branch of `FieldSelector.select_tuple_fields/4` had no
+  fixture at all. `:get_tile` gives that branch one: `:corner` is a typed map
+  with its own `:x` and `:y`, so the same field can be asked for flat and
+  nested and the two answers compared.
+
+  `private? true` on the ETS table for the reason `Test.Account` has it — see
+  #55 and the note in `CLAUDE.md`. Writes must stay in the test process.
+  """
+  use Ash.Resource,
+    domain: AshIntrospection.Test.TupleSelectionDomain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private?(true)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+  end
+
+  actions do
+    defaults([:read])
+
+    action :get_tile, :tuple do
+      constraints(
+        fields: [
+          label: [type: :string],
+          corner: [type: :map, constraints: [fields: [x: [type: :float], y: [type: :float]]]]
+        ]
+      )
+
+      run(fn _input, _context -> {:ok, {"north-west", %{x: 1.5, y: 2.5}}} end)
+    end
+  end
+end


### PR DESCRIPTION
Two latent-correctness fixes in `field_selector.ex`, shipped together because
both are the same kind of fault — one shape handled inconsistently across
sibling branches — and both live in that one file.

Closes #35
Closes #45

## #35 — tuple nested selection: a real bug, not a no-op

The issue asked for a test before a fix, in case the two spellings already
agreed. **They did not.** Measured on `main` at `b99e5a3` against a tuple of
`{label :: string, corner :: map(x, y)}` holding `{"north-west", %{x: 1.5,
y: 2.5}}`:

| Request | Response |
| --- | --- |
| `["label", "corner"]` | `%{"label" => "north-west", "corner" => %{"x" => 1.5, "y" => 2.5}}` |
| `[%{"corner" => ["x", "y"]}]` | `%{}` |
| `["label", %{"corner" => ["x"], "label" => nil}]` | `%{"label" => "north-west", "corner" => nil}` |

Three answers to one request. The `{:nested, ...}` branch of
`select_tuple_fields/4` built its entry as `{field_name, nested_template}` from
the raw wire name; `ResultProcessor` matches a nested entry as
`{field_atom, nested} when is_atom(field_atom)`, so the string key fell through
its catch-all and nothing was written. The `{:multi_nested, ...}` branch had
already resolved the atom, which is why the same field spelled a third way
arrived `nil` instead of missing.

The fix is one word: `field_atom` instead of `field_name`.

### What this does not fix — #66

Keying it correctly makes the two nested spellings agree. It does not make
either return the value. A nested entry carries no tuple index, and
`FieldExtractor.convert_tuple_to_map/2` places a field only when it has one, so
`corner` now arrives `nil` rather than missing. Fixing that needs a template
shape `ResultProcessor` and `FieldExtractor` both understand — both files are
outside this change — so it is filed as #66 and pinned here by an assertion
under a "the gap this fix does not close" heading. Change that assertion when
#66 lands; do not delete it.

There was no tuple fixture with a nested-selectable field: `Test.Post.get_bounds`
carries two floats, so this branch had no coverage at all.
`test/support/tuple_selection_resources.ex` adds `Test.MapTile`, in a new file
per the shared-fixture rule, with `private? true` on its ETS table.

## #45 — the `||` key lookup: latent for data, live as an inconsistency

The issue's "latent" verdict holds for **data loss**: `:args` is a map and
`:fields` is a list, and neither `%{}` nor `[]` is falsy, so no well-formed
request loses a value. I found no path where either value can be `false` or
`nil` in a legitimate request.

The idiom is not inert, though. `||` returns its **right** operand when both
sides are falsy, so a present-and-`false` value survives under the string key
and is erased under the atom key. Measured on `main` at `b99e5a3` against
`Test.LoadRestrictions.Article`, whose `:slug` calculation takes no arguments:

| Request | `main` |
| --- | --- |
| `%{"slug" => %{fields: false}}` | `{:ok, ...}` — loaded, selection dropped |
| `%{"slug" => %{"fields" => false}}` | `{:error, {:invalid_field_selection, :slug, :calculation, []}}` |

One request, two answers, decided by which key form the caller built. Both
forms reach here — the atom form is why `atomize_nested_value/3` carries
`%{args: _}` and `%{fields: _}` clauses alongside the string ones. So: latent
for corruption, live as an atom-vs-string divergence on malformed input.

`fetch_either_key/2` does `Map.fetch/2` on the atom key then the string key, in
the style of `plain_map_field/2` (`result_processor.ex`, #15). Both spellings
now agree, and the second `||` — the duplicated `:fields` read in the
no-args branch, which disagreed with the `Map.has_key?` cond in the args branch
— is gone with it.

`nil` keeps its own meaning. A JSON `null` under `:args` says "no arguments",
not "arguments I could not name", so the `not is_nil/1` guard stays and both
null cases answer exactly as they did before.

`lib/ash_introspection/rpc/error.ex:68` also has an `||`, but it is a different
shape — it prefers `:fields` over a differently named `:field`, both atoms —
and is left alone.

## Test plan

- `mix format --check-formatted` — clean
- `mix compile --force --warnings-as-errors` — clean
- `mix test` — **1 doctest, 376 tests, 0 failures** (`main` at `e16e5dc` is
  359 + 1 after #27; +17 here, 6 for #35 and 11 for #45)
- `mix hex.audit` — no retired packages
- `mix deps.audit` — no vulnerabilities

Every new test was checked to fail before its fix: 3 of 6 in the #35 file and
4 of 11 in the #45 file fail on `main`. The rest are premise and
no-regression pins.

## Untouched

The six `check_load_allowed!/3` guards from #19 are not in either changed
region — tuple selection appends no load, and `get_args_and_fields/1` is a
pure helper. `grep -n 'load ++ \|load_acc ++'` still returns the same six
sites.

`introspection.ex`, `result_processor.ex` and the `pipeline.ex` moduledoc are
untouched. This branch is rebased onto #27 (`e16e5dc`), which changed all three;
the only overlap was `docs/roadmap.md`, resolved by keeping both sets of
entries.

## Documentation

- `docs/roadmap.md`: #35 and #45 move to Shipped with their SHAs; #66 replaces
  #35 in the correctness list; #45 leaves housekeeping, which keeps #27 and #39.
- `CLAUDE.md`: two lessons — the three extraction-template entry shapes and
  which consumer reads each (a shape nothing matches is dropped in silence),
  and the `||` falsy-operand asymmetry with the grep that keeps it out. The
  "definition of green" count is corrected to 359 + 1, measured at `e16e5dc`;
  it still read 366 + 1 from before #27 deleted the dead code's tests.
